### PR TITLE
feat: improve local-ci reliability and agent output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,17 @@ local-ci
 # Run specific stages
 local-ci fmt clippy
 
+# Emit machine-readable output for agents
+local-ci --json
+
 # Disable cache
 local-ci --no-cache
 
 # Auto-fix formatting
 local-ci --fix
+
+# Stop at first failure
+local-ci --fail-fast
 
 # Verbose output
 local-ci --verbose
@@ -55,10 +61,29 @@ local-ci --version
 - **test**: Tests (cargo test --workspace)
 - **check**: Compile check (cargo check)
 
+Unknown stage names now fail fast (instead of being silently ignored).
+
 ## Caching
 
 Cache is stored in `.local-ci-cache` and based on MD5 hash of all `.rs` and `.toml` files. Cache is skipped for:
 - `.git`, `target`, `.github`, `scripts`, `.claude` directories
+
+Each stage cache entry includes the command signature, so changing command args invalidates stale cache entries automatically.
+
+## Agent/Automation Mode
+
+Use `--json` for deterministic machine-readable output:
+
+```bash
+local-ci --json
+```
+
+Sample schema:
+- `version`
+- `duration_ms`
+- `passed`
+- `failed`
+- `results[]` with `name`, `command`, `status`, `duration_ms`, `cache_hit`, optional `output`, optional `error`
 
 ## License
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSelectStagesKnown(t *testing.T) {
+	stages := availableStages()
+	got, err := selectStages([]string{"fmt", "test"}, stages)
+	if err != nil {
+		t.Fatalf("selectStages returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 stages, got %d", len(got))
+	}
+	if got[0].Name != "fmt" || got[1].Name != "test" {
+		t.Fatalf("unexpected stage order: %s, %s", got[0].Name, got[1].Name)
+	}
+}
+
+func TestSelectStagesUnknown(t *testing.T) {
+	_, err := selectStages([]string{"fmt", "nope"}, availableStages())
+	if err == nil {
+		t.Fatal("expected error for unknown stage, got nil")
+	}
+}
+
+func TestCacheRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cache := map[string]string{
+		"fmt":    "hash-a",
+		"clippy": "hash-b",
+	}
+
+	if err := saveCache(cache, dir); err != nil {
+		t.Fatalf("saveCache failed: %v", err)
+	}
+	loaded, err := loadCache(dir)
+	if err != nil {
+		t.Fatalf("loadCache failed: %v", err)
+	}
+	if loaded["fmt"] != "hash-a" || loaded["clippy"] != "hash-b" {
+		t.Fatalf("unexpected cache roundtrip contents: %#v", loaded)
+	}
+}
+
+func TestComputeSourceHashIgnoresTarget(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "main.rs")
+	targetDir := filepath.Join(dir, "target")
+	targetFile := filepath.Join(targetDir, "junk.rs")
+
+	if err := os.WriteFile(srcPath, []byte("fn main() {}"), 0o644); err != nil {
+		t.Fatalf("write src failed: %v", err)
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target failed: %v", err)
+	}
+	if err := os.WriteFile(targetFile, []byte("changed"), 0o644); err != nil {
+		t.Fatalf("write target failed: %v", err)
+	}
+
+	h1, err := computeSourceHash(dir)
+	if err != nil {
+		t.Fatalf("computeSourceHash #1 failed: %v", err)
+	}
+
+	// Changing files under target/ should not affect hash.
+	if err := os.WriteFile(targetFile, []byte("changed again"), 0o644); err != nil {
+		t.Fatalf("rewrite target failed: %v", err)
+	}
+	h2, err := computeSourceHash(dir)
+	if err != nil {
+		t.Fatalf("computeSourceHash #2 failed: %v", err)
+	}
+
+	if h1 != h2 {
+		t.Fatalf("expected stable hash when target changes: %s vs %s", h1, h2)
+	}
+}


### PR DESCRIPTION
Deepens local-ci for developer and agent workflows before push.\n\nIncluded:\n- strict stage validation (unknown stages now error)\n- --json machine-readable report output\n- cache key includes source hash + command signature\n- required command availability check for cargo\n- --fail-fast support\n- deterministic cache file ordering\n- new tests for stage selection, cache roundtrip, and hash ignore rules\n- README updates for new behavior\n\nValidation:\n- go test ./...\n- gofmt -w main.go main_test.go