### PR TITLE
chore: wire nix-cache via flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ cd local-ci
 go build -o local-ci
 ```
 
+## Nix / Attic Cache
+
+This repo includes a `flake.nix` configured with:
+- `nixConfig.extra-substituters = [ "https://nix-cache.stevedores.org" ]`
+
+Use:
+
+```bash
+nix develop
+go build -o local-ci
+```
+
 ## Usage
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "local-ci - lightweight local CI runner";
+
+  nixConfig = {
+    extra-substituters = [ "https://nix-cache.stevedores.org" ];
+  };
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            go
+            gnumake
+            git
+            attic-client
+          ];
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- add repository flake.nix with nixConfig.extra-substituters set to https://nix-cache.stevedores.org
- provide a Nix dev shell for local-ci development (go, gnumake, git, attic-client)
- document Nix/Attic usage in README

## Validation
- go test ./...

## Notes
- implemented via flake.nix per standard cache integration pattern
- no absolute local paths added