### PR TITLE
fix test gaps: generalize --fix tests and add bun tool coverage

### DIFF
--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -128,7 +128,7 @@ func TestFixFlagSwapsFmtCommand(t *testing.T) {
 
 	// Simulate --fix behavior from main.go
 	for i := range stages {
-		if stages[i].Name == "fmt" && len(stages[i].FixCmd) > 0 {
+		if len(stages[i].FixCmd) > 0 {
 			stages[i].Cmd = stages[i].FixCmd
 			stages[i].Check = false
 		}
@@ -160,7 +160,7 @@ func TestFixFlagNoFixCmd(t *testing.T) {
 
 	// Simulate --fix — should not modify stages without FixCmd
 	for i := range stages {
-		if stages[i].Name == "fmt" && len(stages[i].FixCmd) > 0 {
+		if len(stages[i].FixCmd) > 0 {
 			stages[i].Cmd = stages[i].FixCmd
 			stages[i].Check = false
 		}

--- a/toolcheck_test.go
+++ b/toolcheck_test.go
@@ -121,3 +121,29 @@ func TestSystemToolsHaveRequiredFields(t *testing.T) {
 		}
 	}
 }
+
+func TestBunToolsHaveRequiredFields(t *testing.T) {
+	for _, tool := range bunTools {
+		if tool.Name == "" {
+			t.Error("tool name should not be empty")
+		}
+		if tool.Command == "" {
+			t.Errorf("tool %q command should not be empty", tool.Name)
+		}
+		if tool.InstallCmd == "" {
+			t.Errorf("tool %q install command should not be empty", tool.Name)
+		}
+	}
+}
+
+func TestGetMissingToolsForKind(t *testing.T) {
+	rustHints := GetMissingToolsWithHints(ProjectKindRust)
+	if rustHints == nil {
+		t.Error("should return non-nil map for Rust")
+	}
+
+	tsHints := GetMissingToolsWithHints(ProjectKindTypeScript)
+	if tsHints == nil {
+		t.Error("should return non-nil map for TypeScript")
+	}
+}


### PR DESCRIPTION
- pipeline_test.go: --fix simulation now applies to all stages with FixCmd (not just fmt), matching the generalized production behavior
- toolcheck_test.go: add TestBunToolsHaveRequiredFields and TestGetMissingToolsForKind for TypeScript/Bun tool checking coverage