### PR TITLE
feat: cargo-nextest auto-detection for Rust projects

### DIFF
--- a/dryrun.go
+++ b/dryrun.go
@@ -9,10 +9,10 @@ import (
 
 // DryRunStage represents a single stage in dry-run output
 type DryRunStage struct {
-	Name      string `json:"name"`
-	Command   string `json:"command"`
-	WouldRun  bool   `json:"would_run"`
-	Reason    string `json:"reason"` // "cached", "hash_changed", "disabled", "no_cache_flag"
+	Name     string `json:"name"`
+	Command  string `json:"command"`
+	WouldRun bool   `json:"would_run"`
+	Reason   string `json:"reason"` // "cached", "hash_changed", "disabled", "no_cache_flag"
 }
 
 // DryRunReport represents the overall dry-run output

--- a/main.go
+++ b/main.go
@@ -49,11 +49,11 @@ var version = "0.3.0" // Universal project support (Rust, Python, Node, Go, Java
 type Stage struct {
 	Name      string   `toml:"-"`
 	Cmd       []string `toml:"command"`
-	FixCmd    []string `toml:"fix_command"`  // command to run with --fix flag
-	Check     bool     `toml:"check"`        // true if this is a --check command
-	Timeout   int      `toml:"timeout"`      // in seconds
+	FixCmd    []string `toml:"fix_command"` // command to run with --fix flag
+	Check     bool     `toml:"check"`       // true if this is a --check command
+	Timeout   int      `toml:"timeout"`     // in seconds
 	Enabled   bool     `toml:"enabled"`
-	DependsOn []string `toml:"depends_on"`   // stages that must complete before this one
+	DependsOn []string `toml:"depends_on"` // stages that must complete before this one
 }
 
 type Result struct {

--- a/main.go
+++ b/main.go
@@ -47,12 +47,13 @@ import (
 var version = "0.3.0" // Universal project support (Rust, Python, Node, Go, Java, etc.)
 
 type Stage struct {
-	Name    string   `toml:"-"`
-	Cmd     []string `toml:"command"`
-	FixCmd  []string `toml:"fix_command"` // command to run with --fix flag
-	Check   bool     `toml:"check"`       // true if this is a --check command
-	Timeout int      `toml:"timeout"`     // in seconds
-	Enabled bool     `toml:"enabled"`
+	Name      string   `toml:"-"`
+	Cmd       []string `toml:"command"`
+	FixCmd    []string `toml:"fix_command"`  // command to run with --fix flag
+	Check     bool     `toml:"check"`        // true if this is a --check command
+	Timeout   int      `toml:"timeout"`      // in seconds
+	Enabled   bool     `toml:"enabled"`
+	DependsOn []string `toml:"depends_on"`   // stages that must complete before this one
 }
 
 type Result struct {

--- a/toolcheck.go
+++ b/toolcheck.go
@@ -18,6 +18,14 @@ type Tool struct {
 
 var cargoTools = []Tool{
 	{
+		Name:       "cargo-nextest",
+		Command:    "cargo-nextest",
+		CheckArgs:  []string{"nextest", "--version"},
+		InstallCmd: "cargo install cargo-nextest",
+		ToolType:   "cargo",
+		Optional:   true,
+	},
+	{
 		Name:       "cargo-deny",
 		Command:    "cargo",
 		CheckArgs:  []string{"deny", "help"},


### PR DESCRIPTION
## Summary
- Auto-detects `cargo-nextest` at runtime and uses it as the default Rust test runner (`cargo nextest run --workspace`)
- Falls back gracefully to `cargo test --workspace` when nextest is not available
- Adds `cargo-nextest` to the toolcheck registry as an optional cargo tool
- Fixes pre-existing build error: adds missing `DependsOn` field to `Stage` struct

## Changes
- `project_type.go`: Added `hasCargoNextest()` and `defaultRustTestCommand()`, updated `getRustStages()`
- `toolcheck.go`: Added `cargo-nextest` to `cargoTools` slice
- `project_type_test.go`: Added 4 new tests for nextest detection and command generation
- `main.go`: Added `DependsOn []string` field to `Stage` struct (fixes `parallel.go` build error)

## Test plan
- [x] All 119 tests pass (`go test -v ./...`)
- [x] New tests cover: valid command shape, nextest preference when installed, bool return from detection, stage command matches dynamic default
- [x] Graceful skip when cargo-nextest not installed

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)