### PR TITLE
feat(remote): named host presets via --remote-host (DGX Spark / aivcs2)

### DIFF
--- a/.local-ci-remote.toml.example
+++ b/.local-ci-remote.toml.example
@@ -8,6 +8,29 @@
 # - Disable stages that don't work remotely
 # - Use different caching directory on shared storage
 # - Skip stages that are redundant with CI
+# - Define named host presets so callers can write
+#     local-ci --remote-host aivcs2
+#   instead of repeating the full ssh spec, session, and remote dir.
+
+# Named SSH+tmux targets. Reference with `local-ci --remote-host <name>`.
+# Required: host. Optional: session, remote_dir, description.
+
+[hosts.aivcs2]
+host        = "aivcs@aivcs2"
+session     = "aivcs2-onion"
+remote_dir  = "/data/builds/local-ci"
+description = "DGX Spark — Grace+Blackwell, ARM64"
+
+[hosts.studio]
+host        = "aivcs@aivcs.local"
+description = "Mac Studio M2 Ultra"
+
+[hosts.discovery]
+host        = "aivcs@discovery.local"
+
+[hosts.uranus]
+host        = "aivcs@100.81.115.15"
+description = "uranus.local via Tailscale"
 
 [cache]
 # Remote cache directory (relative to project root)

--- a/REMOTE_CI_SETUP.md
+++ b/REMOTE_CI_SETUP.md
@@ -383,6 +383,45 @@ $ # Still in tmux session 'onion'
 $ cargo build  # Run manual commands after CI
 ```
 
+## Named Host Presets
+
+If you regularly target the same nodes, define `[hosts.<name>]` entries in
+`.local-ci-remote.toml` (see `.local-ci-remote.toml.example`) and use
+`--remote-host <name>` instead of repeating ssh / session / remote-dir flags
+on every invocation:
+
+```toml
+[hosts.aivcs2]
+host        = "aivcs@aivcs2"
+session     = "aivcs2-onion"
+remote_dir  = "/data/builds/local-ci"
+description = "DGX Spark — Grace+Blackwell, ARM64"
+```
+
+```bash
+# Equivalent to: local-ci --remote aivcs@aivcs2 --session aivcs2-onion --remote-dir /data/builds/local-ci
+local-ci --remote-host aivcs2
+
+# Mix-and-match: reuse the host preset but override session for this run
+local-ci --remote-host aivcs2 --session experiment
+```
+
+Precedence: an explicit CLI flag (`--remote`, `--session`, `--remote-dir`)
+always wins over the preset's value. The preset only fills in fields that
+the user did not pass. Unknown preset names produce an error listing the
+ones that *are* defined.
+
+### DGX Spark (aivcs2) notes
+
+- Architecture is `aarch64-unknown-linux-gnu`; building large Rust workspaces
+  benefits from a local toolchain (`rustup default stable-aarch64`) and a
+  warmed `~/.cargo/registry` on the same SSD as `remote_dir`.
+- CUDA-aware crates can pick up the Blackwell SM via `CUDA_PATH` and
+  `LD_LIBRARY_PATH`; set those in the tmux session or via a stage-level
+  environment override.
+- Pair with Tailscale + `autossh` (see the Quick Start) for a stable
+  long-lived tmux session that survives roaming between networks.
+
 ## Security Considerations
 
 - **SSH keys**: Use key-based auth only, no passwords

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -20,11 +21,26 @@ type Profile struct {
 
 // Config represents the .local-ci.toml configuration file
 type Config struct {
-	Cache        CacheConfig        `toml:"cache"`
-	Stages       map[string]Stage   `toml:"stages"`
-	Dependencies DepsConfig         `toml:"dependencies"`
-	Workspace    WorkspaceConfig    `toml:"workspace"`
-	Profiles     map[string]Profile `toml:"profiles"`
+	Cache        CacheConfig           `toml:"cache"`
+	Stages       map[string]Stage      `toml:"stages"`
+	Dependencies DepsConfig            `toml:"dependencies"`
+	Workspace    WorkspaceConfig       `toml:"workspace"`
+	Profiles     map[string]Profile    `toml:"profiles"`
+	Hosts        map[string]RemoteHost `toml:"hosts"`
+}
+
+// RemoteHost is a named SSH+tmux target loaded from .local-ci-remote.toml.
+// Lets users say `--remote-host aivcs2` instead of repeating
+// `--remote aivcs@aivcs2 --session aivcs2-onion --remote-dir /data/builds`.
+type RemoteHost struct {
+	// SSH spec: "user@host" or just "host". Required.
+	Host string `toml:"host"`
+	// tmux session name; if empty, the --session flag (or its default) wins.
+	Session string `toml:"session"`
+	// Remote working directory; if empty, falls back to --remote-dir or /tmp/<basename>.
+	RemoteDir string `toml:"remote_dir"`
+	// Human-readable note shown by tooling. Optional.
+	Description string `toml:"description"`
 }
 
 // CacheConfig defines caching behavior
@@ -134,6 +150,18 @@ func LoadConfig(root string, remote bool) (*Config, error) {
 			// Merge remote workspace config if specified
 			if len(remoteCfg.Workspace.Exclude) > 0 {
 				cfg.Workspace.Exclude = remoteCfg.Workspace.Exclude
+			}
+
+			// Carry over named host presets ([hosts.*]) verbatim. These only
+			// live in the remote config file — they have no analogue in the
+			// per-project local config.
+			if len(remoteCfg.Hosts) > 0 {
+				if cfg.Hosts == nil {
+					cfg.Hosts = make(map[string]RemoteHost, len(remoteCfg.Hosts))
+				}
+				for name, h := range remoteCfg.Hosts {
+					cfg.Hosts[name] = h
+				}
 			}
 		}
 	}
@@ -313,6 +341,79 @@ func (c *Config) GetEnabledStages() []string {
 	enabled = append(enabled, extra...)
 
 	return enabled
+}
+
+// GetRemoteHost looks up a named host preset (loaded from
+// `.local-ci-remote.toml`) by name. Returns an actionable error when the
+// name is unknown — listing the names that *are* defined, or saying that
+// no presets exist at all — so users don't have to grep the config file.
+func (c *Config) GetRemoteHost(name string) (*RemoteHost, error) {
+	if len(c.Hosts) == 0 {
+		return nil, fmt.Errorf(
+			"no remote host presets defined; add `[hosts.%s]` to .local-ci-remote.toml",
+			name,
+		)
+	}
+	h, ok := c.Hosts[name]
+	if !ok {
+		available := make([]string, 0, len(c.Hosts))
+		for n := range c.Hosts {
+			available = append(available, n)
+		}
+		sort.Strings(available)
+		return nil, fmt.Errorf(
+			"remote host preset %q not found; available: %s",
+			name,
+			strings.Join(available, ", "),
+		)
+	}
+	if strings.TrimSpace(h.Host) == "" {
+		return nil, fmt.Errorf(
+			"remote host preset %q has empty `host` field in .local-ci-remote.toml",
+			name,
+		)
+	}
+	return &h, nil
+}
+
+// ResolvedRemoteTarget is the result of merging a `[hosts.<name>]` preset
+// with command-line overrides. Empty fields mean "use the caller's default".
+type ResolvedRemoteTarget struct {
+	Host      string
+	Session   string
+	RemoteDir string
+}
+
+// ResolveRemoteHost applies a named preset onto flag-derived defaults using
+// flag > preset > default precedence. Each `userSet*` argument indicates
+// whether the CLI flag was explicitly passed (vs. left at its default), so
+// that an explicit `--session onion` still beats a preset with a non-default
+// session value.
+//
+// Pulled out of main() so it can be unit-tested.
+func (c *Config) ResolveRemoteHost(
+	name, hostFlag, sessionFlag, remoteDirFlag string,
+	userSetSession, userSetRemoteDir bool,
+) (ResolvedRemoteTarget, error) {
+	preset, err := c.GetRemoteHost(name)
+	if err != nil {
+		return ResolvedRemoteTarget{}, err
+	}
+	out := ResolvedRemoteTarget{
+		Host:      hostFlag,
+		Session:   sessionFlag,
+		RemoteDir: remoteDirFlag,
+	}
+	if out.Host == "" {
+		out.Host = preset.Host
+	}
+	if !userSetSession && preset.Session != "" {
+		out.Session = preset.Session
+	}
+	if !userSetRemoteDir && preset.RemoteDir != "" {
+		out.RemoteDir = preset.RemoteDir
+	}
+	return out, nil
 }
 
 // GetProfile returns a profile by name, validating that all referenced stages exist.

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -329,5 +330,213 @@ func TestDefaultStagesHaveCorrectProperties(t *testing.T) {
 		if stages[name].Enabled {
 			t.Errorf("%s should be disabled by default", name)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Named remote-host presets
+// ---------------------------------------------------------------------------
+
+const sampleRemoteTomlWithHosts = `
+[hosts.aivcs2]
+host = "aivcs@aivcs2"
+session = "aivcs2-onion"
+remote_dir = "/data/builds/local-ci"
+description = "DGX Spark — ARM64 + Blackwell"
+
+[hosts.studio]
+host = "aivcs@aivcs.local"
+`
+
+func writeRemoteTomlWithHosts(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".local-ci-remote.toml"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// LoadConfig also reads .local-ci.toml if present; make sure it isn't, so
+	// we exercise the "no local config, only remote presets" path.
+	return dir
+}
+
+func TestRemoteHostsParseFromTOML(t *testing.T) {
+	dir := writeRemoteTomlWithHosts(t, sampleRemoteTomlWithHosts)
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if len(cfg.Hosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %d: %#v", len(cfg.Hosts), cfg.Hosts)
+	}
+	h, ok := cfg.Hosts["aivcs2"]
+	if !ok {
+		t.Fatal("expected hosts.aivcs2 to be parsed")
+	}
+	if h.Host != "aivcs@aivcs2" {
+		t.Errorf("Host: got %q, want aivcs@aivcs2", h.Host)
+	}
+	if h.Session != "aivcs2-onion" {
+		t.Errorf("Session: got %q, want aivcs2-onion", h.Session)
+	}
+	if h.RemoteDir != "/data/builds/local-ci" {
+		t.Errorf("RemoteDir: got %q, want /data/builds/local-ci", h.RemoteDir)
+	}
+}
+
+func TestRemoteHostsLookup_Found(t *testing.T) {
+	dir := writeRemoteTomlWithHosts(t, sampleRemoteTomlWithHosts)
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	h, err := cfg.GetRemoteHost("aivcs2")
+	if err != nil {
+		t.Fatalf("GetRemoteHost: %v", err)
+	}
+	if h.Host != "aivcs@aivcs2" {
+		t.Errorf("Host: got %q, want aivcs@aivcs2", h.Host)
+	}
+}
+
+func TestRemoteHostsLookup_NotFound(t *testing.T) {
+	dir := writeRemoteTomlWithHosts(t, sampleRemoteTomlWithHosts)
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	_, err = cfg.GetRemoteHost("unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown host, got nil")
+	}
+	// Error should mention the available host names so users know what's defined.
+	msg := err.Error()
+	for _, name := range []string{"aivcs2", "studio"} {
+		if !strings.Contains(msg, name) {
+			t.Errorf("error message should list available host %q; got: %s", name, msg)
+		}
+	}
+}
+
+func TestRemoteHostsLookup_EmptyHostField(t *testing.T) {
+	// A preset with no `host =` entry is malformed — surface this rather than
+	// silently SSHing to "".
+	dir := writeRemoteTomlWithHosts(t, `
+[hosts.broken]
+session = "x"
+`)
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	_, err = cfg.GetRemoteHost("broken")
+	if err == nil {
+		t.Fatal("expected error for preset with empty host field, got nil")
+	}
+}
+
+func TestResolveRemoteHost_FlagBeatsPreset(t *testing.T) {
+	dir := writeRemoteTomlWithHosts(t, sampleRemoteTomlWithHosts)
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	// User explicitly passed --session experiment + --remote-dir /alt.
+	got, err := cfg.ResolveRemoteHost("aivcs2",
+		"",           // no --remote → preset host wins
+		"experiment", // explicit --session → wins over preset
+		"/alt",       // explicit --remote-dir → wins over preset
+		true /* userSetSession */, true /* userSetRemoteDir */)
+	if err != nil {
+		t.Fatalf("ResolveRemoteHost: %v", err)
+	}
+	if got.Host != "aivcs@aivcs2" {
+		t.Errorf("Host: got %q, want aivcs@aivcs2", got.Host)
+	}
+	if got.Session != "experiment" {
+		t.Errorf("Session: got %q, want experiment (CLI override)", got.Session)
+	}
+	if got.RemoteDir != "/alt" {
+		t.Errorf("RemoteDir: got %q, want /alt (CLI override)", got.RemoteDir)
+	}
+}
+
+func TestResolveRemoteHost_PresetFillsUnsetFlags(t *testing.T) {
+	dir := writeRemoteTomlWithHosts(t, sampleRemoteTomlWithHosts)
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	// User passed no overrides; --session was left at its default "onion".
+	got, err := cfg.ResolveRemoteHost("aivcs2",
+		"",      // no --remote
+		"onion", // default --session value
+		"",      // no --remote-dir
+		false /* userSetSession */, false /* userSetRemoteDir */)
+	if err != nil {
+		t.Fatalf("ResolveRemoteHost: %v", err)
+	}
+	if got.Host != "aivcs@aivcs2" {
+		t.Errorf("Host: got %q, want aivcs@aivcs2", got.Host)
+	}
+	if got.Session != "aivcs2-onion" {
+		t.Errorf("Session: got %q, want aivcs2-onion (preset)", got.Session)
+	}
+	if got.RemoteDir != "/data/builds/local-ci" {
+		t.Errorf("RemoteDir: got %q, want /data/builds/local-ci (preset)", got.RemoteDir)
+	}
+}
+
+func TestResolveRemoteHost_ExplicitDefaultStillWins(t *testing.T) {
+	// Edge case: user passed --session onion (the literal default). We track
+	// that with userSetSession=true, so it must beat the preset's session.
+	dir := writeRemoteTomlWithHosts(t, sampleRemoteTomlWithHosts)
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	got, err := cfg.ResolveRemoteHost("aivcs2", "", "onion", "",
+		true /* userSetSession */, false)
+	if err != nil {
+		t.Fatalf("ResolveRemoteHost: %v", err)
+	}
+	if got.Session != "onion" {
+		t.Errorf("Session: got %q, want onion (explicit user flag)", got.Session)
+	}
+}
+
+func TestResolveRemoteHost_RemoteFlagBeatsPresetHost(t *testing.T) {
+	dir := writeRemoteTomlWithHosts(t, sampleRemoteTomlWithHosts)
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	got, err := cfg.ResolveRemoteHost("aivcs2",
+		"other@elsewhere", "", "", false, false)
+	if err != nil {
+		t.Fatalf("ResolveRemoteHost: %v", err)
+	}
+	if got.Host != "other@elsewhere" {
+		t.Errorf("Host: got %q, want other@elsewhere (--remote overrides preset)", got.Host)
+	}
+}
+
+func TestRemoteHostsLookup_NoPresetsDefined(t *testing.T) {
+	// LoadConfig with remote=true but no [hosts.*] sections at all → lookup
+	// must surface a clear "no presets defined" error, not just "not found".
+	dir := writeRemoteTomlWithHosts(t, `# no hosts here
+[stages.fmt]
+enabled = true
+`)
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	_, err = cfg.GetRemoteHost("aivcs2")
+	if err == nil {
+		t.Fatal("expected error when no presets exist, got nil")
+	}
+	if !strings.Contains(err.Error(), "no remote host presets") {
+		t.Errorf("error message should mention 'no remote host presets'; got: %s", err.Error())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -186,6 +186,7 @@ func main() {
 		flagVersion       = flag.Bool("version", false, "Print version")
 		flagAll           = flag.Bool("all", false, "Run all stages including disabled ones")
 		flagRemote        = flag.String("remote", "", "Run remotely on specified SSH host (e.g., user@host)")
+		flagRemoteHost    = flag.String("remote-host", "", "Run remotely using a named preset from .local-ci-remote.toml (`[hosts.<name>]`)")
 		flagSession       = flag.String("session", "onion", "tmux session name for remote execution")
 		flagRemoteTimeout = flag.Int("remote-timeout", 30, "SSH operation timeout in seconds")
 		flagRemoteDir     = flag.String("remote-dir", "", "Remote working directory (defaults to /tmp/<basename>)")
@@ -243,10 +244,42 @@ func main() {
 		}
 	}
 
-	// Load configuration
-	config, err := LoadConfig(cwd, *flagRemote != "")
+	// Load configuration. Pull the remote overlay whenever either remote-mode
+	// flag is set — `--remote-host` resolves names from [hosts.*] in that file.
+	config, err := LoadConfig(cwd, *flagRemote != "" || *flagRemoteHost != "")
 	if err != nil {
 		fatalf("Failed to load config: %v", err)
+	}
+
+	// Resolve `--remote-host <name>` into the underlying ssh/session/dir
+	// values. Explicit CLI flags always win over preset fields, so e.g.
+	// `--remote-host aivcs2 --session experiment` reuses the preset's host
+	// but overrides its session for this one run.
+	if *flagRemoteHost != "" {
+		userSetSession := false
+		userSetRemoteDir := false
+		flag.Visit(func(f *flag.Flag) {
+			switch f.Name {
+			case "session":
+				userSetSession = true
+			case "remote-dir":
+				userSetRemoteDir = true
+			}
+		})
+		resolved, err := config.ResolveRemoteHost(
+			*flagRemoteHost,
+			*flagRemote, *flagSession, *flagRemoteDir,
+			userSetSession, userSetRemoteDir,
+		)
+		if err != nil {
+			fatalf("%v", err)
+		}
+		*flagRemote = resolved.Host
+		*flagSession = resolved.Session
+		*flagRemoteDir = resolved.RemoteDir
+		if *flagVerbose {
+			printf("📍 Using host preset %q → %s\n", *flagRemoteHost, *flagRemote)
+		}
 	}
 
 	// Apply profile if specified


### PR DESCRIPTION
## Summary

Extends the SSH+tmux remote execution shipped in #61 / #62 with **named host presets** so contributors who target the same nodes repeatedly (e.g. our DGX Spark `aivcs2`, the Mac Studio, `discovery.local`, `uranus.local`) can run:

```bash
local-ci --remote-host aivcs2
```

instead of the full

```bash
local-ci --remote aivcs@aivcs2 --session aivcs2-onion --remote-dir /data/builds/local-ci
```

Presets live in `.local-ci-remote.toml` under `[hosts.<name>]` (sibling to the existing `[cache]` / `[stages.*]` sections).

## How it works

`.local-ci-remote.toml`:
```toml
[hosts.aivcs2]
host        = "aivcs@aivcs2"
session     = "aivcs2-onion"
remote_dir  = "/data/builds/local-ci"
description = "DGX Spark — Grace+Blackwell, ARM64"
```

CLI:
```bash
local-ci --remote-host aivcs2                          # uses all preset fields
local-ci --remote-host aivcs2 --session experiment    # preset host, override session
local-ci --remote-host aivcs2 --remote other@elsewhere # --remote wins over preset.host
```

**Precedence:** explicit CLI flag > preset field > default. We use `flag.Visit` to distinguish "user passed `--session onion`" from "user accepted the default `onion`", so an explicit flag — even one that happens to match the default — wins.

## Files changed

- `config.go` — adds `RemoteHost` struct, `Hosts map[string]RemoteHost` on `Config`, `GetRemoteHost(name)`, and a pure `Config.ResolveRemoteHost(...)` that is the actual resolution logic (so it can be unit-tested without spawning the binary).
- `main.go` — adds `--remote-host` flag, loads the remote overlay whenever either remote-mode flag is set, calls `ResolveRemoteHost` and pipes results into the existing `RemoteExecutor` path.
- `config_test.go` — 9 new tests, TDD-first (the lookup ones failed before the implementation existed).
- `.local-ci-remote.toml.example` — ships presets for the four nodes we use today (`aivcs2`, `studio`, `discovery`, `uranus`).
- `REMOTE_CI_SETUP.md` — new \"Named Host Presets\" section + DGX Spark-specific notes (ARM64 toolchain hint, CUDA env-var pointers).

## Test plan

- [x] `go test ./...` — ok (1.075s)
- [x] `gofmt -l .` returns nothing
- [x] `go vet ./...` clean
- [x] `local-ci --help` shows the new flag
- [ ] Smoke test against the actual `aivcs2` node — I can't reach it from this environment, leaving for the user

## Why this targets `main` instead of `develop`

`develop` is currently behind `main` by PRs #60–#62 — including the #61 base remote-execution work that this PR extends. Cleanest base is `main`. A subsequent sync of `main` → `develop` will carry this along with #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)