### PR TITLE
feat(remote): complete SSH+tmux remote execution (#61)

### DIFF
--- a/.local-ci-remote.toml.example
+++ b/.local-ci-remote.toml.example
@@ -1,56 +1,53 @@
 # .local-ci-remote.toml — Remote-specific configuration overrides
 #
-# This file allows you to override .local-ci.toml settings when running
-# builds on a remote machine via `local-ci --remote aivcs@studio`
+# Reach cluster nodes over Tailscale MagicDNS (see REMOTE_CI_SETUP.md).
+# Copy to ~/.local-ci-remote.toml or project root.
 #
-# Common use cases:
-# - Increase timeouts for slower remote machines
-# - Disable stages that don't work remotely
-# - Use different caching directory on shared storage
-# - Skip stages that are redundant with CI
-# - Define named host presets so callers can write
-#     local-ci --remote-host aivcs2
-#   instead of repeating the full ssh spec, session, and remote dir.
+# SSH users:
+#   macOS nodes (discovery, uranus, …) → aivcs or stevenirvin
+#   DGX Spark (spark-bde7 / sparky)     → aivcs2
 
 # Named SSH+tmux targets. Reference with `local-ci --remote-host <name>`.
 # Required: host. Optional: session, remote_dir, description.
 
-[hosts.aivcs2]
-host        = "aivcs@aivcs2"
-session     = "aivcs2-onion"
+[hosts.sparky]
+host        = "aivcs2@spark-bde7"
+session     = "sparky-onion"
 remote_dir  = "/data/builds/local-ci"
-description = "DGX Spark — Grace+Blackwell, ARM64"
+description = "DGX Spark — Grace+Blackwell, ARM64 (Linux user: aivcs2)"
 
-[hosts.studio]
-host        = "aivcs@aivcs.local"
-description = "Mac Studio M2 Ultra"
+# Back-compat alias for scripts that still pass --remote-host aivcs2
+[hosts.aivcs2]
+host        = "aivcs2@spark-bde7"
+session     = "sparky-onion"
+remote_dir  = "/data/builds/local-ci"
+description = "alias for sparky preset"
 
 [hosts.discovery]
 host        = "aivcs@discovery"
-description = "Tailscale macOS node — MagicDNS (100.103.163.28); enable Remote Login"
+description = "Tailscale macOS — use stevenirvin@discovery if that is your account"
 
 [hosts.uranus]
 host        = "aivcs@uranus"
-description = "Tailscale macOS node — MagicDNS (100.81.115.15)"
+description = "Tailscale macOS — use stevenirvin@uranus if that is your account"
+
+[hosts.studio]
+host        = "aivcs@downhome"
+description = "This Mac / downhome on tailnet (override user to stevenirvin if needed)"
 
 [cache]
-# Remote cache directory (relative to project root)
-# If unset, uses .local-ci-cache-remote
 cache_dir = ".local-ci-cache-remote"
 skip_dirs = [".git", "target", ".github", "scripts", ".claude"]
 include_patterns = ["*.rs", "*.toml"]
 
-# Override timeouts for slower remote machine
 [stages.fmt]
-timeout = 180  # increased from 120
+timeout = 180
 
 [stages.clippy]
-timeout = 900  # increased from 600
+timeout = 900
 
 [stages.test]
-timeout = 1800  # increased from 1200
-# Optional: export CARGO_TEST_THREADS=4 for parallelism on powerful nodes
+timeout = 1800
 
-# Example: disable deny stage on remote (security check redundant with CI)
 [stages.deny]
 enabled = false

--- a/.local-ci-remote.toml.example
+++ b/.local-ci-remote.toml.example
@@ -33,15 +33,20 @@ description = "Tailscale macOS — enable Remote Login if SSH is refused"
 host        = "uranus"
 platform    = "macos"
 
+[hosts.downhome]
+host        = "downhome"
+platform    = "macos"
+description = "Local — Apple Silicon Mac (this machine), user aivcs"
+
 [hosts.studio]
 host        = "downhome"
 platform    = "macos"
-description = "This Mac on tailnet"
+description = "alias for downhome (local operator Mac)"
 
 [hosts.msi]
 host        = "msi"
 platform    = "windows"
-description = "Windows 11 + RTX 5070 — offline when logged out; OpenSSH + WSL/tmux for remote-ci"
+description = "Windows 11 + RTX 5070 — online when logged in; OpenSSH + WSL/tmux for remote-ci"
 
 [cache]
 cache_dir = ".local-ci-cache-remote"

--- a/.local-ci-remote.toml.example
+++ b/.local-ci-remote.toml.example
@@ -1,7 +1,7 @@
 # .local-ci-remote.toml — Remote-specific configuration overrides
 #
 # Canonical SSH users: docs/SSH_IDENTITY.md
-# Reach nodes over Tailscale MagicDNS (see REMOTE_CI_SETUP.md).
+# Reach nodes in Tailscale only (see docs/SSH_IDENTITY.md → "In Tailscale").
 
 [ssh_defaults]
 macos_user = "aivcs"

--- a/.local-ci-remote.toml.example
+++ b/.local-ci-remote.toml.example
@@ -6,6 +6,7 @@
 [ssh_defaults]
 macos_user = "aivcs"
 linux_spark_user = "aivcs2"
+windows_user = "aivcs"
 
 # Named presets — host is bare tailnet name; user comes from [ssh_defaults].
 
@@ -36,6 +37,11 @@ platform    = "macos"
 host        = "downhome"
 platform    = "macos"
 description = "This Mac on tailnet"
+
+[hosts.msi]
+host        = "msi"
+platform    = "windows"
+description = "Windows 11 + RTX 5070 — offline when logged out; OpenSSH + WSL/tmux for remote-ci"
 
 [cache]
 cache_dir = ".local-ci-cache-remote"

--- a/.local-ci-remote.toml.example
+++ b/.local-ci-remote.toml.example
@@ -1,39 +1,41 @@
 # .local-ci-remote.toml — Remote-specific configuration overrides
 #
-# Reach cluster nodes over Tailscale MagicDNS (see REMOTE_CI_SETUP.md).
-# Copy to ~/.local-ci-remote.toml or project root.
-#
-# SSH users:
-#   macOS nodes (discovery, uranus, …) → aivcs or stevenirvin
-#   DGX Spark (spark-bde7 / sparky)     → aivcs2
+# Canonical SSH users: docs/SSH_IDENTITY.md
+# Reach nodes over Tailscale MagicDNS (see REMOTE_CI_SETUP.md).
 
-# Named SSH+tmux targets. Reference with `local-ci --remote-host <name>`.
-# Required: host. Optional: session, remote_dir, description.
+[ssh_defaults]
+macos_user = "aivcs"
+linux_spark_user = "aivcs2"
+
+# Named presets — host is bare tailnet name; user comes from [ssh_defaults].
 
 [hosts.sparky]
-host        = "aivcs2@spark-bde7"
+host        = "spark-bde7"
+platform    = "linux_spark"
 session     = "sparky-onion"
 remote_dir  = "/data/builds/local-ci"
-description = "DGX Spark — Grace+Blackwell, ARM64 (Linux user: aivcs2)"
+description = "DGX Spark — Grace+Blackwell, ARM64"
 
-# Back-compat alias for scripts that still pass --remote-host aivcs2
 [hosts.aivcs2]
-host        = "aivcs2@spark-bde7"
+host        = "spark-bde7"
+platform    = "linux_spark"
 session     = "sparky-onion"
 remote_dir  = "/data/builds/local-ci"
 description = "alias for sparky preset"
 
 [hosts.discovery]
-host        = "aivcs@discovery"
-description = "Tailscale macOS — use stevenirvin@discovery if that is your account"
+host        = "discovery"
+platform    = "macos"
+description = "Tailscale macOS — enable Remote Login if SSH is refused"
 
 [hosts.uranus]
-host        = "aivcs@uranus"
-description = "Tailscale macOS — use stevenirvin@uranus if that is your account"
+host        = "uranus"
+platform    = "macos"
 
 [hosts.studio]
-host        = "aivcs@downhome"
-description = "This Mac / downhome on tailnet (override user to stevenirvin if needed)"
+host        = "downhome"
+platform    = "macos"
+description = "This Mac on tailnet"
 
 [cache]
 cache_dir = ".local-ci-cache-remote"

--- a/.local-ci-remote.toml.example
+++ b/.local-ci-remote.toml.example
@@ -26,11 +26,12 @@ host        = "aivcs@aivcs.local"
 description = "Mac Studio M2 Ultra"
 
 [hosts.discovery]
-host        = "aivcs@discovery.local"
+host        = "aivcs@discovery"
+description = "Tailscale macOS node — MagicDNS (100.103.163.28); enable Remote Login"
 
 [hosts.uranus]
-host        = "aivcs@100.81.115.15"
-description = "uranus.local via Tailscale"
+host        = "aivcs@uranus"
+description = "Tailscale macOS node — MagicDNS (100.81.115.15)"
 
 [cache]
 # Remote cache directory (relative to project root)
@@ -48,14 +49,8 @@ timeout = 900  # increased from 600
 
 [stages.test]
 timeout = 1800  # increased from 1200
+# Optional: export CARGO_TEST_THREADS=4 for parallelism on powerful nodes
 
 # Example: disable deny stage on remote (security check redundant with CI)
 [stages.deny]
 enabled = false
-
-# Example: increase test parallelism on powerful Mac Studio
-[stages.test]
-# Note: command array syntax still applies
-# To use environment variable for job count:
-# export CARGO_TEST_THREADS=4
-# local-ci --remote aivcs@studio test

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -26,32 +26,30 @@ local-ci --remote aivcs@100.90.209.9 fmt clippy
 ## Implementation Steps
 
 ### Phase 1: Add Flags to main.go
-- [ ] Add `--remote` flag (SSH host)
-- [ ] Add `--session` flag (tmux session name, default: "onion")
-- [ ] Add `--remote-timeout` flag (SSH operation timeout, default: 30s)
+- [x] Add `--remote` flag (SSH host)
+- [x] Add `--session` flag (tmux session name, default: "onion")
+- [x] Add `--remote-timeout` flag (SSH operation timeout, default: 30s)
+- [x] Add `--remote-dir` flag (remote working directory)
 
 ### Phase 2: Create remote.go
-- [ ] `RemoteExecutor` struct with SSH client config
-- [ ] `executeStageRemote(stage, cmd, host, session) → Result`
-- [ ] `runCommandInSession(host, session, cmd) → (output, exitCode, error)`
-- [ ] `pollExitCode(host, sentinel) → exitCode`
-- [ ] Sentinel file strategy: `/tmp/kc_exit_<task_id_hex>`
+- [x] `RemoteExecutor` struct with SSH client config
+- [x] `ExecuteStage(stage) → Result`
+- [x] `runInSession(host, session, cmd) → (output, error)`
+- [x] `pollExitCode(host, sentinel) → exitCode`
+- [x] Sentinel file strategy: `/tmp/kc_exit_<stage>_<nanos>`
 
 ### Phase 3: Modify main.go Execution
-- [ ] Route stage execution based on --remote flag
-- [ ] Local execution: current behavior (unchanged)
-- [ ] Remote execution: new RemoteExecutor path
-- [ ] Preserve output streaming and result collection
+- [x] Route stage execution based on --remote flag
+- [x] Local execution: current behavior (unchanged)
+- [x] Remote execution: new RemoteExecutor path
+- [x] Preserve output streaming and result collection
+- [x] Workspace sync via rsync before remote stages (#63)
+- [x] Named host presets via `--remote-host` (#64)
 
 ### Phase 4: Testing
-- [ ] Unit tests: SSH connection mocking
-- [ ] Integration test: Run against aivcs@100.90.209.9
-- [ ] Test cases:
-  - [ ] Successful stage execution
-  - [ ] Failed stage (non-zero exit code)
-  - [ ] Timeout handling
-  - [ ] SSH connection failure
-  - [ ] Multiple stages in sequence
+- [x] Unit tests: mock SSH (success, failure, connection error)
+- [x] Unit tests: shell quoting + discovery/uranus presets
+- [ ] Integration test: Run against live cluster nodes (operator smoke test)
 
 ## Files to Create/Modify
 

--- a/README.md
+++ b/README.md
@@ -519,25 +519,16 @@ Sample schema:
 
 Run expensive stages (clippy, test) on remote hardware via **Tailscale + SSH+tmux** before pushing — keeps GitHub Actions minutes for PR gates only. See [REMOTE_CI_SETUP.md](REMOTE_CI_SETUP.md) for full setup.
 
-**Prerequisite:** nodes must appear in `tailscale status` (e.g. `uranus`, `discovery`). Use MagicDNS short names — not `.local` mDNS.
+**Prerequisite:** nodes in `tailscale status`. SSH users are codified in [docs/SSH_IDENTITY.md](docs/SSH_IDENTITY.md) — `aivcs` on macOS, `aivcs2` on Spark.
 
 ```bash
-tailscale status          # verify uranus / discovery are online
-tailscale ping uranus     # quick reachability check
+tailscale ping uranus
+ssh aivcs@uranus echo ok
+ssh aivcs2@spark-bde7 echo ok
 
-# Direct SSH target (Tailscale MagicDNS)
-local-ci --remote aivcs@uranus --session onion fmt clippy test
-local-ci --remote stevenirvin@discovery test
-local-ci --remote aivcs2@spark-bde7 --session sparky-onion test   # Spark Linux user
-
-# Named presets from .local-ci-remote.toml
-local-ci --remote-host sparky      # aivcs2@spark-bde7
-local-ci --remote-host uranus      # aivcs@uranus (or stevenirvin@uranus in config)
-local-ci --remote-host discovery
+local-ci --remote-host uranus fmt clippy test
+local-ci --remote-host sparky test
 local-ci --list-remote-hosts
-
-# Plan without executing
-local-ci --remote-host uranus --dry-run
 ```
 
 Flags: `--remote`, `--session`, `--remote-dir`, `--remote-timeout`, `--remote-host`, `--list-remote-hosts`.

--- a/README.md
+++ b/README.md
@@ -517,20 +517,25 @@ Sample schema:
 
 ## Remote execution
 
-Run expensive stages (clippy, test) on remote hardware via SSH+tmux **before pushing** — keeps GitHub Actions minutes for PR gates only. See [REMOTE_CI_SETUP.md](REMOTE_CI_SETUP.md) for full setup.
+Run expensive stages (clippy, test) on remote hardware via **Tailscale + SSH+tmux** before pushing — keeps GitHub Actions minutes for PR gates only. See [REMOTE_CI_SETUP.md](REMOTE_CI_SETUP.md) for full setup.
+
+**Prerequisite:** nodes must appear in `tailscale status` (e.g. `uranus`, `discovery`). Use MagicDNS short names — not `.local` mDNS.
 
 ```bash
-# Direct SSH target (issue #61 flags)
-local-ci --remote aivcs@discovery.local --session onion --remote-dir /tmp/my-project fmt clippy test
-local-ci --remote aivcs@100.81.115.15 --remote-timeout 60 test   # uranus.local
+tailscale status          # verify uranus / discovery are online
+tailscale ping uranus     # quick reachability check
 
-# Named presets from .local-ci-remote.toml (includes discovery + uranus)
-local-ci --remote-host discovery
+# Direct SSH target (Tailscale MagicDNS)
+local-ci --remote aivcs@uranus --session onion fmt clippy test
+local-ci --remote aivcs@discovery --remote-timeout 60 test
+
+# Named presets from .local-ci-remote.toml
 local-ci --remote-host uranus
+local-ci --remote-host discovery
 local-ci --list-remote-hosts
 
-# Plan a remote run without executing
-local-ci --remote-host discovery --dry-run
+# Plan without executing
+local-ci --remote-host uranus --dry-run
 ```
 
 Flags: `--remote`, `--session`, `--remote-dir`, `--remote-timeout`, `--remote-host`, `--list-remote-hosts`.

--- a/README.md
+++ b/README.md
@@ -517,15 +517,23 @@ Sample schema:
 
 ## Remote execution
 
-SSH+tmux remote runs and named host presets are documented in [REMOTE_CI_SETUP.md](REMOTE_CI_SETUP.md).
+Run expensive stages (clippy, test) on remote hardware via SSH+tmux **before pushing** — keeps GitHub Actions minutes for PR gates only. See [REMOTE_CI_SETUP.md](REMOTE_CI_SETUP.md) for full setup.
 
 ```bash
-# Named preset from ~/.local-ci-remote.toml or project .local-ci-remote.toml
-local-ci --remote-host aivcs2
+# Direct SSH target (issue #61 flags)
+local-ci --remote aivcs@discovery.local --session onion --remote-dir /tmp/my-project fmt clippy test
+local-ci --remote aivcs@100.81.115.15 --remote-timeout 60 test   # uranus.local
 
-# List configured presets
+# Named presets from .local-ci-remote.toml (includes discovery + uranus)
+local-ci --remote-host discovery
+local-ci --remote-host uranus
 local-ci --list-remote-hosts
+
+# Plan a remote run without executing
+local-ci --remote-host discovery --dry-run
 ```
+
+Flags: `--remote`, `--session`, `--remote-dir`, `--remote-timeout`, `--remote-host`, `--list-remote-hosts`.
 
 ## MCP server
 

--- a/README.md
+++ b/README.md
@@ -517,11 +517,10 @@ Sample schema:
 
 ## Remote execution
 
-Run expensive stages (clippy, test) on remote hardware via **Tailscale + SSH+tmux** before pushing — keeps GitHub Actions minutes for PR gates only. See [REMOTE_CI_SETUP.md](REMOTE_CI_SETUP.md) for full setup.
-
-**Prerequisite:** `tailscale status` — **local** machine is **`downhome`** (Apple Silicon Mac, user `aivcs`). Remote nodes: uranus, discovery, spark-bde7, **msi** (Windows 11 / RTX 5070). See [docs/SSH_IDENTITY.md](docs/SSH_IDENTITY.md).
+Run expensive stages on remote nodes **in Tailscale** before pushing — keeps GitHub Actions minutes for PR gates only. **`downhome`** is this Mac (`aivcs`). Fleet map: [docs/SSH_IDENTITY.md](docs/SSH_IDENTITY.md) → **In Tailscale**.
 
 ```bash
+tailscale status
 tailscale ping uranus
 ssh aivcs@uranus echo ok
 ssh aivcs2@spark-bde7 echo ok

--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ Sample schema:
 
 Run expensive stages (clippy, test) on remote hardware via **Tailscale + SSH+tmux** before pushing — keeps GitHub Actions minutes for PR gates only. See [REMOTE_CI_SETUP.md](REMOTE_CI_SETUP.md) for full setup.
 
-**Prerequisite:** nodes in `tailscale status`. SSH identity: [docs/SSH_IDENTITY.md](docs/SSH_IDENTITY.md) — fleet is uranus, discovery, downhome (macOS), spark-bde7 (Linux), **msi** (Windows 11 / RTX 5070, offline when logged out).
+**Prerequisite:** `tailscale status` — **local** machine is **`downhome`** (Apple Silicon Mac, user `aivcs`). Remote nodes: uranus, discovery, spark-bde7, **msi** (Windows 11 / RTX 5070). See [docs/SSH_IDENTITY.md](docs/SSH_IDENTITY.md).
 
 ```bash
 tailscale ping uranus

--- a/README.md
+++ b/README.md
@@ -527,10 +527,12 @@ tailscale ping uranus     # quick reachability check
 
 # Direct SSH target (Tailscale MagicDNS)
 local-ci --remote aivcs@uranus --session onion fmt clippy test
-local-ci --remote aivcs@discovery --remote-timeout 60 test
+local-ci --remote stevenirvin@discovery test
+local-ci --remote aivcs2@spark-bde7 --session sparky-onion test   # Spark Linux user
 
 # Named presets from .local-ci-remote.toml
-local-ci --remote-host uranus
+local-ci --remote-host sparky      # aivcs2@spark-bde7
+local-ci --remote-host uranus      # aivcs@uranus (or stevenirvin@uranus in config)
 local-ci --remote-host discovery
 local-ci --list-remote-hosts
 

--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ Sample schema:
 
 Run expensive stages (clippy, test) on remote hardware via **Tailscale + SSH+tmux** before pushing — keeps GitHub Actions minutes for PR gates only. See [REMOTE_CI_SETUP.md](REMOTE_CI_SETUP.md) for full setup.
 
-**Prerequisite:** nodes in `tailscale status`. SSH users are codified in [docs/SSH_IDENTITY.md](docs/SSH_IDENTITY.md) — `aivcs` on macOS, `aivcs2` on Spark.
+**Prerequisite:** nodes in `tailscale status`. SSH identity: [docs/SSH_IDENTITY.md](docs/SSH_IDENTITY.md) — fleet is uranus, discovery, downhome (macOS), spark-bde7 (Linux), **msi** (Windows 11 / RTX 5070, offline when logged out).
 
 ```bash
 tailscale ping uranus

--- a/REMOTE_CI_SETUP.md
+++ b/REMOTE_CI_SETUP.md
@@ -385,35 +385,21 @@ $ cargo build  # Run manual commands after CI
 
 ## Tailscale (required for cluster nodes)
 
-Remote CI targets (`uranus`, `discovery`, `spark-bde7`, etc.) are reached over the **Tailscale tailnet**, not LAN mDNS (`.local`) or public IPs.
+Remote CI targets are on the **Tailscale tailnet**. SSH users are unified — see **[docs/SSH_IDENTITY.md](docs/SSH_IDENTITY.md)**:
+
+- **macOS** → `aivcs@<tailnet-name>`
+- **DGX Spark** → `aivcs2@spark-bde7` (`--remote-host sparky`)
 
 ```bash
-# 1. Confirm tailnet connectivity
 tailscale status
-tailscale ping uranus
-tailscale ping discovery
-
-# 2. SSH must work over MagicDNS (install your pubkey on the remote, or use Tailscale SSH)
 ssh aivcs@uranus echo ok
-# Alternative when Tailscale SSH ACLs are configured:
-# tailscale ssh uranus echo ok
+ssh aivcs2@spark-bde7 echo ok
 
-# 3. Run local-ci against a preset or explicit host
-local-ci --remote-host sparky fmt clippy test    # aivcs2@spark-bde7
-local-ci --remote-host uranus fmt clippy test    # aivcs@uranus
-local-ci --remote stevenirvin@discovery test     # alternate macOS user
+local-ci --remote-host sparky fmt clippy test
+local-ci --remote-host uranus --dry-run
 ```
 
-| Node | Tailscale name | SSH user | Example host string |
-|------|----------------|----------|---------------------|
-| uranus | `uranus` | `aivcs` or `stevenirvin` | `aivcs@uranus` |
-| discovery | `discovery` | `aivcs` or `stevenirvin` | `aivcs@discovery` |
-| DGX Spark (sparky) | `spark-bde7` | **`aivcs2`** | `aivcs2@spark-bde7` |
-| downhome (studio) | `downhome` | `aivcs` or `stevenirvin` | `aivcs@downhome` |
-
-macOS nodes share two operator accounts (**`aivcs`**, **`stevenirvin`**). Spark uses a dedicated Linux account **`aivcs2`**. Pick the user that has your SSH key in `authorized_keys`.
-
-Use **`user@<tailscale-name>`** in `.local-ci-remote.toml` — not `*.local` mDNS hostnames.
+Presets use bare tailnet names; `[ssh_defaults]` in `.local-ci-remote.toml` supplies the user.
 
 ## Named Host Presets
 
@@ -423,16 +409,20 @@ If you regularly target the same nodes, define `[hosts.<name>]` entries in
 on every invocation:
 
 ```toml
+[ssh_defaults]
+macos_user = "aivcs"
+linux_spark_user = "aivcs2"
+
 [hosts.sparky]
-host        = "aivcs2@spark-bde7"
+host        = "spark-bde7"
+platform    = "linux_spark"
 session     = "sparky-onion"
 remote_dir  = "/data/builds/local-ci"
-description = "DGX Spark — Linux user aivcs2"
 ```
 
 ```bash
-# Equivalent to: local-ci --remote aivcs2@spark-bde7 --session sparky-onion --remote-dir /data/builds/local-ci
-local-ci --remote-host sparky
+local-ci --remote-host sparky   # → aivcs2@spark-bde7
+```
 
 # Mix-and-match: reuse the host preset but override session for this run
 local-ci --remote-host sparky --session experiment

--- a/REMOTE_CI_SETUP.md
+++ b/REMOTE_CI_SETUP.md
@@ -383,6 +383,34 @@ $ # Still in tmux session 'onion'
 $ cargo build  # Run manual commands after CI
 ```
 
+## Tailscale (required for cluster nodes)
+
+Remote CI targets (`uranus`, `discovery`, `spark-bde7`, etc.) are reached over the **Tailscale tailnet**, not LAN mDNS (`.local`) or public IPs.
+
+```bash
+# 1. Confirm tailnet connectivity
+tailscale status
+tailscale ping uranus
+tailscale ping discovery
+
+# 2. SSH must work over MagicDNS (install your pubkey on the remote, or use Tailscale SSH)
+ssh aivcs@uranus echo ok
+# Alternative when Tailscale SSH ACLs are configured:
+# tailscale ssh uranus echo ok
+
+# 3. Run local-ci against a preset or explicit host
+local-ci --remote-host uranus fmt clippy test
+local-ci --remote aivcs@discovery --session onion test
+```
+
+| Node | Tailscale name | Tailscale IP | Notes |
+|------|----------------|-------------|-------|
+| uranus | `uranus` | `100.81.115.15` | macOS; SSH on port 22 |
+| discovery | `discovery` | `100.103.163.28` | macOS; enable **Remote Login** in System Settings if SSH is refused |
+| DGX Spark | `spark-bde7` | `100.124.89.47` | Linux; use `[hosts.aivcs2]` preset pattern |
+
+Use **`aivcs@<tailscale-name>`** in `.local-ci-remote.toml` — not `*.local` hostnames.
+
 ## Named Host Presets
 
 If you regularly target the same nodes, define `[hosts.<name>]` entries in

--- a/REMOTE_CI_SETUP.md
+++ b/REMOTE_CI_SETUP.md
@@ -399,17 +399,21 @@ ssh aivcs@uranus echo ok
 # tailscale ssh uranus echo ok
 
 # 3. Run local-ci against a preset or explicit host
-local-ci --remote-host uranus fmt clippy test
-local-ci --remote aivcs@discovery --session onion test
+local-ci --remote-host sparky fmt clippy test    # aivcs2@spark-bde7
+local-ci --remote-host uranus fmt clippy test    # aivcs@uranus
+local-ci --remote stevenirvin@discovery test     # alternate macOS user
 ```
 
-| Node | Tailscale name | Tailscale IP | Notes |
-|------|----------------|-------------|-------|
-| uranus | `uranus` | `100.81.115.15` | macOS; SSH on port 22 |
-| discovery | `discovery` | `100.103.163.28` | macOS; enable **Remote Login** in System Settings if SSH is refused |
-| DGX Spark | `spark-bde7` | `100.124.89.47` | Linux; use `[hosts.aivcs2]` preset pattern |
+| Node | Tailscale name | SSH user | Example host string |
+|------|----------------|----------|---------------------|
+| uranus | `uranus` | `aivcs` or `stevenirvin` | `aivcs@uranus` |
+| discovery | `discovery` | `aivcs` or `stevenirvin` | `aivcs@discovery` |
+| DGX Spark (sparky) | `spark-bde7` | **`aivcs2`** | `aivcs2@spark-bde7` |
+| downhome (studio) | `downhome` | `aivcs` or `stevenirvin` | `aivcs@downhome` |
 
-Use **`aivcs@<tailscale-name>`** in `.local-ci-remote.toml` — not `*.local` hostnames.
+macOS nodes share two operator accounts (**`aivcs`**, **`stevenirvin`**). Spark uses a dedicated Linux account **`aivcs2`**. Pick the user that has your SSH key in `authorized_keys`.
+
+Use **`user@<tailscale-name>`** in `.local-ci-remote.toml` — not `*.local` mDNS hostnames.
 
 ## Named Host Presets
 
@@ -419,19 +423,19 @@ If you regularly target the same nodes, define `[hosts.<name>]` entries in
 on every invocation:
 
 ```toml
-[hosts.aivcs2]
-host        = "aivcs@aivcs2"
-session     = "aivcs2-onion"
+[hosts.sparky]
+host        = "aivcs2@spark-bde7"
+session     = "sparky-onion"
 remote_dir  = "/data/builds/local-ci"
-description = "DGX Spark — Grace+Blackwell, ARM64"
+description = "DGX Spark — Linux user aivcs2"
 ```
 
 ```bash
-# Equivalent to: local-ci --remote aivcs@aivcs2 --session aivcs2-onion --remote-dir /data/builds/local-ci
-local-ci --remote-host aivcs2
+# Equivalent to: local-ci --remote aivcs2@spark-bde7 --session sparky-onion --remote-dir /data/builds/local-ci
+local-ci --remote-host sparky
 
 # Mix-and-match: reuse the host preset but override session for this run
-local-ci --remote-host aivcs2 --session experiment
+local-ci --remote-host sparky --session experiment
 ```
 
 Precedence: an explicit CLI flag (`--remote`, `--session`, `--remote-dir`)
@@ -439,16 +443,9 @@ always wins over the preset's value. The preset only fills in fields that
 the user did not pass. Unknown preset names produce an error listing the
 ones that *are* defined.
 
-### DGX Spark (aivcs2) notes
+### DGX Spark (sparky / spark-bde7) notes
 
-- Architecture is `aarch64-unknown-linux-gnu`; building large Rust workspaces
-  benefits from a local toolchain (`rustup default stable-aarch64`) and a
-  warmed `~/.cargo/registry` on the same SSD as `remote_dir`.
-- CUDA-aware crates can pick up the Blackwell SM via `CUDA_PATH` and
-  `LD_LIBRARY_PATH`; set those in the tmux session or via a stage-level
-  environment override.
-- Pair with Tailscale + `autossh` (see the Quick Start) for a stable
-  long-lived tmux session that survives roaming between networks.
+- SSH as **`aivcs2@spark-bde7`** — not `aivcs`. Preset: `--remote-host sparky` (alias: `--remote-host aivcs2`).
 
 ## Security Considerations
 

--- a/config.go
+++ b/config.go
@@ -30,8 +30,8 @@ type Config struct {
 }
 
 // RemoteHost is a named SSH+tmux target loaded from .local-ci-remote.toml.
-// Lets users say `--remote-host aivcs2` instead of repeating
-// `--remote aivcs@aivcs2 --session aivcs2-onion --remote-dir /data/builds`.
+// Lets users say `--remote-host sparky` instead of repeating
+// `--remote aivcs2@spark-bde7 --session sparky-onion --remote-dir /data/builds`.
 type RemoteHost struct {
 	// SSH spec: "user@host" or just "host". Required.
 	Host string `toml:"host"`

--- a/config.go
+++ b/config.go
@@ -158,7 +158,7 @@ func LoadConfig(root string, remote bool) (*Config, error) {
 			// Carry over named host presets ([hosts.*]) verbatim. These only
 			// live in the remote config file — they have no analogue in the
 			// per-project local config.
-			if remoteCfg.SSHDefaults.MacOSUser != "" || remoteCfg.SSHDefaults.LinuxSparkUser != "" {
+			if remoteCfg.SSHDefaults.MacOSUser != "" || remoteCfg.SSHDefaults.LinuxSparkUser != "" || remoteCfg.SSHDefaults.WindowsUser != "" {
 				cfg.SSHDefaults = remoteCfg.SSHDefaults
 			}
 			if len(remoteCfg.Hosts) > 0 {

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ type Profile struct {
 
 // Config represents the .local-ci.toml configuration file
 type Config struct {
+	SSHDefaults  RemoteSSHDefaults     `toml:"ssh_defaults"`
 	Cache        CacheConfig           `toml:"cache"`
 	Stages       map[string]Stage      `toml:"stages"`
 	Dependencies DepsConfig            `toml:"dependencies"`
@@ -33,8 +34,10 @@ type Config struct {
 // Lets users say `--remote-host sparky` instead of repeating
 // `--remote aivcs2@spark-bde7 --session sparky-onion --remote-dir /data/builds`.
 type RemoteHost struct {
-	// SSH spec: "user@host" or just "host". Required.
+	// Tailscale name or full user@host. Bare names expand via [ssh_defaults].
 	Host string `toml:"host"`
+	// macos (default) | linux_spark — picks user from [ssh_defaults].
+	Platform string `toml:"platform"`
 	// tmux session name; if empty, the --session flag (or its default) wins.
 	Session string `toml:"session"`
 	// Remote working directory; if empty, falls back to --remote-dir or /tmp/<basename>.
@@ -155,6 +158,9 @@ func LoadConfig(root string, remote bool) (*Config, error) {
 			// Carry over named host presets ([hosts.*]) verbatim. These only
 			// live in the remote config file — they have no analogue in the
 			// per-project local config.
+			if remoteCfg.SSHDefaults.MacOSUser != "" || remoteCfg.SSHDefaults.LinuxSparkUser != "" {
+				cfg.SSHDefaults = remoteCfg.SSHDefaults
+			}
 			if len(remoteCfg.Hosts) > 0 {
 				if cfg.Hosts == nil {
 					cfg.Hosts = make(map[string]RemoteHost, len(remoteCfg.Hosts))
@@ -367,6 +373,7 @@ func (c *Config) GetRemoteHost(name string) (*RemoteHost, error) {
 			strings.Join(available, ", "),
 		)
 	}
+	h = c.normalizeRemoteHost(name, h)
 	if strings.TrimSpace(h.Host) == "" {
 		return nil, fmt.Errorf(
 			"remote host preset %q has empty `host` field in .local-ci-remote.toml",
@@ -400,7 +407,7 @@ func (c *Config) ListRemoteHosts() []struct {
 		Description string
 	}, 0, len(names))
 	for _, n := range names {
-		h := c.Hosts[n]
+		h := c.normalizeRemoteHost(n, c.Hosts[n])
 		out = append(out, struct {
 			Name        string
 			Host        string
@@ -442,6 +449,8 @@ func (c *Config) ResolveRemoteHost(
 	}
 	if out.Host == "" {
 		out.Host = preset.Host
+	} else if !strings.Contains(out.Host, "@") {
+		out.Host = NormalizeSSHHost(out.Host, preset.effectivePlatform(name), c.SSHDefaults)
 	}
 	if !userSetSession && preset.Session != "" {
 		out.Session = preset.Session

--- a/config_test.go
+++ b/config_test.go
@@ -338,14 +338,20 @@ func TestDefaultStagesHaveCorrectProperties(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 const sampleRemoteTomlWithHosts = `
+[ssh_defaults]
+macos_user = "aivcs"
+linux_spark_user = "aivcs2"
+
 [hosts.sparky]
-host = "aivcs2@spark-bde7"
+host = "spark-bde7"
+platform = "linux_spark"
 session = "sparky-onion"
 remote_dir = "/data/builds/local-ci"
 description = "DGX Spark — ARM64 + Blackwell"
 
 [hosts.studio]
-host = "aivcs@downhome"
+host = "downhome"
+platform = "macos"
 `
 
 func writeRemoteTomlWithHosts(t *testing.T, body string) string {
@@ -373,8 +379,11 @@ func TestRemoteHostsParseFromTOML(t *testing.T) {
 	if !ok {
 		t.Fatal("expected hosts.sparky to be parsed")
 	}
-	if h.Host != "aivcs2@spark-bde7" {
-		t.Errorf("Host: got %q, want aivcs2@spark-bde7", h.Host)
+	if h.Host != "spark-bde7" {
+		t.Errorf("Host: got %q, want spark-bde7 (bare tailnet name in config)", h.Host)
+	}
+	if h.Platform != remotePlatformLinuxSpark {
+		t.Errorf("Platform: got %q, want linux_spark", h.Platform)
 	}
 	if h.Session != "sparky-onion" {
 		t.Errorf("Session: got %q, want sparky-onion", h.Session)
@@ -395,7 +404,7 @@ func TestRemoteHostsLookup_Found(t *testing.T) {
 		t.Fatalf("GetRemoteHost: %v", err)
 	}
 	if h.Host != "aivcs2@spark-bde7" {
-		t.Errorf("Host: got %q, want aivcs2@spark-bde7", h.Host)
+		t.Errorf("Host: got %q, want aivcs2@spark-bde7 (normalized from bare spark-bde7)", h.Host)
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -338,14 +338,14 @@ func TestDefaultStagesHaveCorrectProperties(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 const sampleRemoteTomlWithHosts = `
-[hosts.aivcs2]
-host = "aivcs@aivcs2"
-session = "aivcs2-onion"
+[hosts.sparky]
+host = "aivcs2@spark-bde7"
+session = "sparky-onion"
 remote_dir = "/data/builds/local-ci"
 description = "DGX Spark — ARM64 + Blackwell"
 
 [hosts.studio]
-host = "aivcs@aivcs.local"
+host = "aivcs@downhome"
 `
 
 func writeRemoteTomlWithHosts(t *testing.T, body string) string {
@@ -369,15 +369,15 @@ func TestRemoteHostsParseFromTOML(t *testing.T) {
 	if len(cfg.Hosts) != 2 {
 		t.Fatalf("expected 2 hosts, got %d: %#v", len(cfg.Hosts), cfg.Hosts)
 	}
-	h, ok := cfg.Hosts["aivcs2"]
+	h, ok := cfg.Hosts["sparky"]
 	if !ok {
-		t.Fatal("expected hosts.aivcs2 to be parsed")
+		t.Fatal("expected hosts.sparky to be parsed")
 	}
-	if h.Host != "aivcs@aivcs2" {
-		t.Errorf("Host: got %q, want aivcs@aivcs2", h.Host)
+	if h.Host != "aivcs2@spark-bde7" {
+		t.Errorf("Host: got %q, want aivcs2@spark-bde7", h.Host)
 	}
-	if h.Session != "aivcs2-onion" {
-		t.Errorf("Session: got %q, want aivcs2-onion", h.Session)
+	if h.Session != "sparky-onion" {
+		t.Errorf("Session: got %q, want sparky-onion", h.Session)
 	}
 	if h.RemoteDir != "/data/builds/local-ci" {
 		t.Errorf("RemoteDir: got %q, want /data/builds/local-ci", h.RemoteDir)
@@ -390,12 +390,12 @@ func TestRemoteHostsLookup_Found(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	h, err := cfg.GetRemoteHost("aivcs2")
+	h, err := cfg.GetRemoteHost("sparky")
 	if err != nil {
 		t.Fatalf("GetRemoteHost: %v", err)
 	}
-	if h.Host != "aivcs@aivcs2" {
-		t.Errorf("Host: got %q, want aivcs@aivcs2", h.Host)
+	if h.Host != "aivcs2@spark-bde7" {
+		t.Errorf("Host: got %q, want aivcs2@spark-bde7", h.Host)
 	}
 }
 
@@ -411,7 +411,7 @@ func TestRemoteHostsLookup_NotFound(t *testing.T) {
 	}
 	// Error should mention the available host names so users know what's defined.
 	msg := err.Error()
-	for _, name := range []string{"aivcs2", "studio"} {
+	for _, name := range []string{"sparky", "studio"} {
 		if !strings.Contains(msg, name) {
 			t.Errorf("error message should list available host %q; got: %s", name, msg)
 		}
@@ -442,7 +442,7 @@ func TestResolveRemoteHost_FlagBeatsPreset(t *testing.T) {
 		t.Fatalf("LoadConfig: %v", err)
 	}
 	// User explicitly passed --session experiment + --remote-dir /alt.
-	got, err := cfg.ResolveRemoteHost("aivcs2",
+	got, err := cfg.ResolveRemoteHost("sparky",
 		"",           // no --remote → preset host wins
 		"experiment", // explicit --session → wins over preset
 		"/alt",       // explicit --remote-dir → wins over preset
@@ -450,8 +450,8 @@ func TestResolveRemoteHost_FlagBeatsPreset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveRemoteHost: %v", err)
 	}
-	if got.Host != "aivcs@aivcs2" {
-		t.Errorf("Host: got %q, want aivcs@aivcs2", got.Host)
+	if got.Host != "aivcs2@spark-bde7" {
+		t.Errorf("Host: got %q, want aivcs2@spark-bde7", got.Host)
 	}
 	if got.Session != "experiment" {
 		t.Errorf("Session: got %q, want experiment (CLI override)", got.Session)
@@ -468,7 +468,7 @@ func TestResolveRemoteHost_PresetFillsUnsetFlags(t *testing.T) {
 		t.Fatalf("LoadConfig: %v", err)
 	}
 	// User passed no overrides; --session was left at its default "onion".
-	got, err := cfg.ResolveRemoteHost("aivcs2",
+	got, err := cfg.ResolveRemoteHost("sparky",
 		"",      // no --remote
 		"onion", // default --session value
 		"",      // no --remote-dir
@@ -476,11 +476,11 @@ func TestResolveRemoteHost_PresetFillsUnsetFlags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveRemoteHost: %v", err)
 	}
-	if got.Host != "aivcs@aivcs2" {
-		t.Errorf("Host: got %q, want aivcs@aivcs2", got.Host)
+	if got.Host != "aivcs2@spark-bde7" {
+		t.Errorf("Host: got %q, want aivcs2@spark-bde7", got.Host)
 	}
-	if got.Session != "aivcs2-onion" {
-		t.Errorf("Session: got %q, want aivcs2-onion (preset)", got.Session)
+	if got.Session != "sparky-onion" {
+		t.Errorf("Session: got %q, want sparky-onion (preset)", got.Session)
 	}
 	if got.RemoteDir != "/data/builds/local-ci" {
 		t.Errorf("RemoteDir: got %q, want /data/builds/local-ci (preset)", got.RemoteDir)
@@ -495,7 +495,7 @@ func TestResolveRemoteHost_ExplicitDefaultStillWins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	got, err := cfg.ResolveRemoteHost("aivcs2", "", "onion", "",
+	got, err := cfg.ResolveRemoteHost("sparky", "", "onion", "",
 		true /* userSetSession */, false)
 	if err != nil {
 		t.Fatalf("ResolveRemoteHost: %v", err)
@@ -511,7 +511,7 @@ func TestResolveRemoteHost_RemoteFlagBeatsPresetHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	got, err := cfg.ResolveRemoteHost("aivcs2",
+	got, err := cfg.ResolveRemoteHost("sparky",
 		"other@elsewhere", "", "", false, false)
 	if err != nil {
 		t.Fatalf("ResolveRemoteHost: %v", err)
@@ -531,8 +531,8 @@ func TestListRemoteHosts_Sorted(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("expected 2 hosts, got %d", len(got))
 	}
-	if got[0].Name != "aivcs2" || got[1].Name != "studio" {
-		t.Fatalf("expected sorted aivcs2, studio; got %#v", got)
+	if got[0].Name != "sparky" || got[1].Name != "studio" {
+		t.Fatalf("expected sorted sparky, studio; got %#v", got)
 	}
 }
 
@@ -547,7 +547,7 @@ enabled = true
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	_, err = cfg.GetRemoteHost("aivcs2")
+	_, err = cfg.GetRemoteHost("sparky")
 	if err == nil {
 		t.Fatal("expected error when no presets exist, got nil")
 	}

--- a/docs/SSH_IDENTITY.md
+++ b/docs/SSH_IDENTITY.md
@@ -4,26 +4,27 @@ Unified SSH logins for **local-ci remote execution** and agent automation over T
 
 ## Fleet
 
-**4 remote compute nodes** (+ operator Mac `downhome`):
+**Local (this machine):** `downhome` — Apple Silicon Mac, user **`aivcs`**. Run `local-ci` here before push; use `--remote-host` to fan out to other nodes.
+
+**4 remote compute nodes:**
 
 | Preset | Tailscale | OS | GPU | User |
 |--------|-----------|-----|-----|------|
+| `downhome` | `downhome` | macOS (Apple Silicon) | — | `aivcs` |
 | `uranus` | `uranus` | macOS | — | `aivcs` |
 | `discovery` | `discovery` | macOS | — | `aivcs` |
 | `sparky` | `spark-bde7` | Linux | Blackwell (DGX) | `aivcs2` |
 | `msi` | `msi` | **Windows 11** | **RTX 5070** | `aivcs` |
 
-| Preset | Tailscale | Role |
-|--------|-----------|------|
-| `studio` | `downhome` | Operator machine (runs `local-ci` locally) |
+Preset alias: `studio` → same as `downhome` (back-compat).
 
-`msi` shows **offline** in `tailscale status` when logged out (last seen ~2d ago until it reconnects).
+`msi` is **online** when logged into Windows and Tailscale; it was offline while logged out.
 
 ## Policy
 
 | Platform | Canonical user | Scope |
 |----------|----------------|-------|
-| **macOS** (tailnet) | `aivcs` | `uranus`, `discovery`, `downhome`, all macOS nodes |
+| **macOS** (tailnet) | `aivcs` | `downhome`, `uranus`, `discovery`, all macOS nodes |
 | **Linux — DGX Spark** | `aivcs2` | `spark-bde7` only (`sparky` preset) |
 | **Windows 11** | `aivcs` | `msi` only (`msi` preset) |
 
@@ -36,7 +37,7 @@ Unified SSH logins for **local-ci remote execution** and agent automation over T
 
 ### Windows (`msi`) caveats
 
-- **Tailscale:** node is unreachable while logged out / offline.
+- **Tailscale:** offline while logged out; online when Windows session is active (check `tailscale ping msi`).
 - **OpenSSH Server** must be enabled on Windows 11 (Settings → Apps → Optional features → OpenSSH Server).
 - **local-ci remote path** uses SSH + **tmux** today — native Windows has no tmux. For GPU builds on msi, use **WSL2** with tmux inside WSL, or run checks locally until native Windows remote support lands.
 
@@ -53,6 +54,7 @@ Bare host names expand at runtime:
 
 | Config `host` | `platform` | Resolved SSH target |
 |---------------|------------|---------------------|
+| `downhome` | `macos` | `aivcs@downhome` |
 | `uranus` | `macos` (default) | `aivcs@uranus` |
 | `discovery` | `macos` | `aivcs@discovery` |
 | `spark-bde7` | `linux_spark` | `aivcs2@spark-bde7` |
@@ -61,16 +63,19 @@ Bare host names expand at runtime:
 ## Operator checklist
 
 ```bash
-tailscale status
+tailscale status    # downhome = this Mac; msi should show online when logged in
+tailscale ping msi
 tailscale ping uranus
-tailscale ping msi    # fails while msi is offline
 
+ssh aivcs@downhome echo ok   # local tailnet name (same user as remote macOS nodes)
 ssh aivcs@uranus echo ok
 ssh aivcs2@spark-bde7 echo ok
-ssh aivcs@msi echo ok   # when msi is online + OpenSSH enabled
+ssh aivcs@msi echo ok        # OpenSSH Server on Windows 11
 
+local-ci                        # run locally on downhome
 local-ci --remote-host uranus --dry-run
 local-ci --remote-host sparky fmt clippy test
+local-ci --remote-host msi test   # WSL + tmux if using full remote path
 ```
 
 ## Adding a node

--- a/docs/SSH_IDENTITY.md
+++ b/docs/SSH_IDENTITY.md
@@ -37,6 +37,8 @@ tailscale ping downhome
 
 Alias: `studio` → `downhome`.
 
+## Policy
+
 | Platform | Canonical user | Scope |
 |----------|----------------|-------|
 | **macOS** (tailnet) | `aivcs` | `downhome`, `uranus`, `discovery`, all macOS nodes |

--- a/docs/SSH_IDENTITY.md
+++ b/docs/SSH_IDENTITY.md
@@ -2,28 +2,51 @@
 
 Unified SSH logins for **local-ci remote execution** and agent automation over Tailscale.
 
+## Fleet
+
+**4 remote compute nodes** (+ operator Mac `downhome`):
+
+| Preset | Tailscale | OS | GPU | User |
+|--------|-----------|-----|-----|------|
+| `uranus` | `uranus` | macOS | — | `aivcs` |
+| `discovery` | `discovery` | macOS | — | `aivcs` |
+| `sparky` | `spark-bde7` | Linux | Blackwell (DGX) | `aivcs2` |
+| `msi` | `msi` | **Windows 11** | **RTX 5070** | `aivcs` |
+
+| Preset | Tailscale | Role |
+|--------|-----------|------|
+| `studio` | `downhome` | Operator machine (runs `local-ci` locally) |
+
+`msi` shows **offline** in `tailscale status` when logged out (last seen ~2d ago until it reconnects).
+
 ## Policy
 
 | Platform | Canonical user | Scope |
 |----------|----------------|-------|
-| **macOS** (tailnet) | `aivcs` | `uranus`, `discovery`, `downhome`, all other macOS build/review nodes |
+| **macOS** (tailnet) | `aivcs` | `uranus`, `discovery`, `downhome`, all macOS nodes |
 | **Linux — DGX Spark** | `aivcs2` | `spark-bde7` only (`sparky` preset) |
+| **Windows 11** | `aivcs` | `msi` only (`msi` preset) |
 
 **Rules**
 
-1. **Automation uses canonical users only** — agents, `local-ci --remote*`, and CI babysit scripts SSH as `aivcs` (macOS) or `aivcs2` (Spark).
-2. **`stevenirvin` is not an automation account** — personal/interactive use only; do not put it in `.local-ci-remote.toml` or agent skills.
-3. **Tailscale MagicDNS** — host field is the tailnet name (`uranus`, `spark-bde7`), not `.local` mDNS or LAN IPs.
+1. **Automation uses canonical users only** — agents, `local-ci --remote*`, and CI babysit scripts use the users above.
+2. **`stevenirvin` is not an automation account** — personal/interactive use only.
+3. **Tailscale MagicDNS** — preset `host` is the tailnet name (`uranus`, `msi`, …), not `.local` mDNS or LAN IPs.
 4. **Explicit `user@host` overrides** — if a preset or `--remote` includes `@`, that user wins (escape hatch only).
 
-## Defaults in config
+### Windows (`msi`) caveats
 
-`.local-ci-remote.toml` centralizes users under `[ssh_defaults]`:
+- **Tailscale:** node is unreachable while logged out / offline.
+- **OpenSSH Server** must be enabled on Windows 11 (Settings → Apps → Optional features → OpenSSH Server).
+- **local-ci remote path** uses SSH + **tmux** today — native Windows has no tmux. For GPU builds on msi, use **WSL2** with tmux inside WSL, or run checks locally until native Windows remote support lands.
+
+## Defaults in config
 
 ```toml
 [ssh_defaults]
 macos_user = "aivcs"
 linux_spark_user = "aivcs2"
+windows_user = "aivcs"
 ```
 
 Bare host names expand at runtime:
@@ -33,16 +56,18 @@ Bare host names expand at runtime:
 | `uranus` | `macos` (default) | `aivcs@uranus` |
 | `discovery` | `macos` | `aivcs@discovery` |
 | `spark-bde7` | `linux_spark` | `aivcs2@spark-bde7` |
+| `msi` | `windows` | `aivcs@msi` |
 
 ## Operator checklist
 
 ```bash
 tailscale status
 tailscale ping uranus
+tailscale ping msi    # fails while msi is offline
 
-# Canonical smoke tests
 ssh aivcs@uranus echo ok
 ssh aivcs2@spark-bde7 echo ok
+ssh aivcs@msi echo ok   # when msi is online + OpenSSH enabled
 
 local-ci --remote-host uranus --dry-run
 local-ci --remote-host sparky fmt clippy test
@@ -50,9 +75,9 @@ local-ci --remote-host sparky fmt clippy test
 
 ## Adding a node
 
-1. Add `[hosts.<preset>]` with bare Tailscale name and correct `platform`.
+1. Add `[hosts.<preset>]` with bare Tailscale name and correct `platform` (`macos`, `linux_spark`, `windows`).
 2. Install the **canonical** user's SSH public key on the remote.
-3. Enable Remote Login (macOS) or `sshd` (Linux).
+3. Enable Remote Login (macOS), `sshd` (Linux), or OpenSSH Server (Windows).
 4. Run `local-ci --remote-host <preset> --dry-run` before heavy stages.
 
 ## Related

--- a/docs/SSH_IDENTITY.md
+++ b/docs/SSH_IDENTITY.md
@@ -1,26 +1,41 @@
 # SSH identity (codified)
 
-Unified SSH logins for **local-ci remote execution** and agent automation over Tailscale.
+Unified SSH logins for **local-ci remote execution** and agent automation.
 
-## Fleet
+**All fleet nodes live in Tailscale only** — use MagicDNS names from `tailscale status`, never `.local` mDNS or LAN IPs.
 
-**Local (this machine):** `downhome` — Apple Silicon Mac, user **`aivcs`**. Run `local-ci` here before push; use `--remote-host` to fan out to other nodes.
+## In Tailscale
 
-**4 remote compute nodes:**
+Source of truth: `tailscale status` (names in the **DNS** column).
 
-| Preset | Tailscale | OS | GPU | User |
-|--------|-----------|-----|-----|------|
+| Tailscale IP | DNS name | OS | Preset | SSH user |
+|--------------|----------|-----|--------|----------|
+| `100.84.125.48` | **`downhome`** | macOS | `downhome` / `studio` | `aivcs` |
+| `100.81.115.15` | `uranus` | macOS | `uranus` | `aivcs` |
+| `100.103.163.28` | `discovery` | macOS | `discovery` | `aivcs` |
+| `100.124.89.47` | `spark-bde7` | linux | `sparky` / `aivcs2` | `aivcs2` |
+| `100.85.43.19` | `msi` | windows | `msi` | `aivcs` |
+
+```bash
+tailscale status
+tailscale ping msi      # reachability over tailnet
+tailscale ping downhome
+```
+
+**Local machine:** you are on **`downhome`** (Apple Silicon Mac, user `aivcs`). Run `local-ci` here; fan out with `--remote-host <preset>`.
+
+**`msi`:** online when logged into Windows + Tailscale; offline when logged out.
+
+## Fleet (presets)
+| Preset | In Tailscale (DNS) | OS | GPU | User |
+|--------|-------------------|-----|-----|------|
 | `downhome` | `downhome` | macOS (Apple Silicon) | — | `aivcs` |
 | `uranus` | `uranus` | macOS | — | `aivcs` |
 | `discovery` | `discovery` | macOS | — | `aivcs` |
 | `sparky` | `spark-bde7` | Linux | Blackwell (DGX) | `aivcs2` |
-| `msi` | `msi` | **Windows 11** | **RTX 5070** | `aivcs` |
+| `msi` | `msi` | Windows 11 | RTX 5070 | `aivcs` |
 
-Preset alias: `studio` → same as `downhome` (back-compat).
-
-`msi` is **online** when logged into Windows and Tailscale; it was offline while logged out.
-
-## Policy
+Alias: `studio` → `downhome`.
 
 | Platform | Canonical user | Scope |
 |----------|----------------|-------|
@@ -32,7 +47,7 @@ Preset alias: `studio` → same as `downhome` (back-compat).
 
 1. **Automation uses canonical users only** — agents, `local-ci --remote*`, and CI babysit scripts use the users above.
 2. **`stevenirvin` is not an automation account** — personal/interactive use only.
-3. **Tailscale MagicDNS** — preset `host` is the tailnet name (`uranus`, `msi`, …), not `.local` mDNS or LAN IPs.
+3. **In Tailscale only** — preset `host` must match the **DNS name** from `tailscale status` (`downhome`, `uranus`, `msi`, …). No `.local`, no raw LAN IPs in presets.
 4. **Explicit `user@host` overrides** — if a preset or `--remote` includes `@`, that user wins (escape hatch only).
 
 ### Windows (`msi`) caveats

--- a/docs/SSH_IDENTITY.md
+++ b/docs/SSH_IDENTITY.md
@@ -1,0 +1,61 @@
+# SSH identity (codified)
+
+Unified SSH logins for **local-ci remote execution** and agent automation over Tailscale.
+
+## Policy
+
+| Platform | Canonical user | Scope |
+|----------|----------------|-------|
+| **macOS** (tailnet) | `aivcs` | `uranus`, `discovery`, `downhome`, all other macOS build/review nodes |
+| **Linux — DGX Spark** | `aivcs2` | `spark-bde7` only (`sparky` preset) |
+
+**Rules**
+
+1. **Automation uses canonical users only** — agents, `local-ci --remote*`, and CI babysit scripts SSH as `aivcs` (macOS) or `aivcs2` (Spark).
+2. **`stevenirvin` is not an automation account** — personal/interactive use only; do not put it in `.local-ci-remote.toml` or agent skills.
+3. **Tailscale MagicDNS** — host field is the tailnet name (`uranus`, `spark-bde7`), not `.local` mDNS or LAN IPs.
+4. **Explicit `user@host` overrides** — if a preset or `--remote` includes `@`, that user wins (escape hatch only).
+
+## Defaults in config
+
+`.local-ci-remote.toml` centralizes users under `[ssh_defaults]`:
+
+```toml
+[ssh_defaults]
+macos_user = "aivcs"
+linux_spark_user = "aivcs2"
+```
+
+Bare host names expand at runtime:
+
+| Config `host` | `platform` | Resolved SSH target |
+|---------------|------------|---------------------|
+| `uranus` | `macos` (default) | `aivcs@uranus` |
+| `discovery` | `macos` | `aivcs@discovery` |
+| `spark-bde7` | `linux_spark` | `aivcs2@spark-bde7` |
+
+## Operator checklist
+
+```bash
+tailscale status
+tailscale ping uranus
+
+# Canonical smoke tests
+ssh aivcs@uranus echo ok
+ssh aivcs2@spark-bde7 echo ok
+
+local-ci --remote-host uranus --dry-run
+local-ci --remote-host sparky fmt clippy test
+```
+
+## Adding a node
+
+1. Add `[hosts.<preset>]` with bare Tailscale name and correct `platform`.
+2. Install the **canonical** user's SSH public key on the remote.
+3. Enable Remote Login (macOS) or `sshd` (Linux).
+4. Run `local-ci --remote-host <preset> --dry-run` before heavy stages.
+
+## Related
+
+- [REMOTE_CI_SETUP.md](../REMOTE_CI_SETUP.md) — SSH+tmux workflow
+- [.local-ci-remote.toml.example](../.local-ci-remote.toml.example) — ship-ready presets

--- a/dryrun.go
+++ b/dryrun.go
@@ -15,15 +15,24 @@ type DryRunStage struct {
 	Reason   string `json:"reason"` // "cached", "hash_changed", "disabled", "no_cache_flag"
 }
 
+// DryRunRemote describes a remote SSH+tmux target when --remote is active.
+type DryRunRemote struct {
+	Host       string `json:"host"`
+	Session    string `json:"session"`
+	WorkDir    string `json:"work_dir"`
+	HostPreset string `json:"host_preset,omitempty"`
+}
+
 // DryRunReport represents the overall dry-run output
 type DryRunReport struct {
 	Workspace  string        `json:"workspace"`
 	SourceHash string        `json:"source_hash"`
+	Remote     *DryRunRemote `json:"remote,omitempty"`
 	Stages     []DryRunStage `json:"stages"`
 }
 
 // BuildDryRunReport creates a dry-run report for the given stages
-func BuildDryRunReport(stages []Stage, cache map[string]string, sourceHash string, noCache bool) DryRunReport {
+func BuildDryRunReport(stages []Stage, cache map[string]string, sourceHash string, noCache bool, remote *DryRunRemote) DryRunReport {
 	workspace, _ := os.Getwd()
 
 	var dryRunStages []DryRunStage
@@ -33,7 +42,6 @@ func BuildDryRunReport(stages []Stage, cache map[string]string, sourceHash strin
 			Command: strings.Join(stage.Cmd, " "),
 		}
 
-		// Determine if stage would run and reason
 		if !stage.Enabled {
 			dryRunStage.WouldRun = false
 			dryRunStage.Reason = "disabled"
@@ -54,6 +62,7 @@ func BuildDryRunReport(stages []Stage, cache map[string]string, sourceHash strin
 	return DryRunReport{
 		Workspace:  workspace,
 		SourceHash: sourceHash,
+		Remote:     remote,
 		Stages:     dryRunStages,
 	}
 }
@@ -67,7 +76,15 @@ func PrintDryRunJSON(report DryRunReport) {
 // PrintDryRunHuman prints dry-run report in human-readable format
 func PrintDryRunHuman(report DryRunReport) {
 	fmt.Printf("📋 Dry-run report for: %s\n", report.Workspace)
-	fmt.Printf("   Source hash: %s\n\n", report.SourceHash)
+	fmt.Printf("   Source hash: %s\n", report.SourceHash)
+	if report.Remote != nil {
+		line := fmt.Sprintf("   Remote: %s (session=%s, work_dir=%s)", report.Remote.Host, report.Remote.Session, report.Remote.WorkDir)
+		if report.Remote.HostPreset != "" {
+			line += fmt.Sprintf(" [preset=%s]", report.Remote.HostPreset)
+		}
+		fmt.Println(line)
+	}
+	fmt.Println()
 
 	fmt.Println("Stages:")
 	for _, stage := range report.Stages {
@@ -80,7 +97,6 @@ func PrintDryRunHuman(report DryRunReport) {
 		fmt.Printf("      Reason: %s\n", stage.Reason)
 	}
 
-	// Summary
 	wouldRun := 0
 	for _, stage := range report.Stages {
 		if stage.WouldRun {

--- a/dryrun_test.go
+++ b/dryrun_test.go
@@ -131,13 +131,13 @@ func TestBuildDryRunReportEmptyStages(t *testing.T) {
 
 func TestBuildDryRunReportRemoteTarget(t *testing.T) {
 	remote := &DryRunRemote{
-		Host:       "aivcs@discovery.local",
+		Host:       "aivcs@discovery",
 		Session:    "onion",
 		WorkDir:    "/tmp/local-ci",
 		HostPreset: "discovery",
 	}
 	report := BuildDryRunReport(nil, nil, "hash", false, remote)
-	if report.Remote == nil || report.Remote.Host != "aivcs@discovery.local" {
+	if report.Remote == nil || report.Remote.Host != "aivcs@discovery" {
 		t.Fatalf("expected remote target in report: %+v", report.Remote)
 	}
 }

--- a/dryrun_test.go
+++ b/dryrun_test.go
@@ -15,7 +15,7 @@ func TestBuildDryRunReportAllCached(t *testing.T) {
 		"test": "hash1",
 	}
 
-	report := BuildDryRunReport(stages, cache, "hash1", false)
+	report := BuildDryRunReport(stages, cache, "hash1", false, nil)
 
 	for _, s := range report.Stages {
 		if s.WouldRun {
@@ -38,7 +38,7 @@ func TestBuildDryRunReportHashChanged(t *testing.T) {
 		"test": "oldhash",
 	}
 
-	report := BuildDryRunReport(stages, cache, "newhash", false)
+	report := BuildDryRunReport(stages, cache, "newhash", false, nil)
 
 	for _, s := range report.Stages {
 		if !s.WouldRun {
@@ -59,7 +59,7 @@ func TestBuildDryRunReportNoCache(t *testing.T) {
 		"fmt": "hash1",
 	}
 
-	report := BuildDryRunReport(stages, cache, "hash1", true)
+	report := BuildDryRunReport(stages, cache, "hash1", true, nil)
 
 	if len(report.Stages) != 1 {
 		t.Fatalf("expected 1 stage, got %d", len(report.Stages))
@@ -78,7 +78,7 @@ func TestBuildDryRunReportDisabledStages(t *testing.T) {
 		{Name: "deny", Cmd: []string{"cargo", "deny"}, Enabled: false},
 	}
 
-	report := BuildDryRunReport(stages, nil, "hash1", true)
+	report := BuildDryRunReport(stages, nil, "hash1", true, nil)
 
 	disabledCount := 0
 	for _, s := range report.Stages {
@@ -106,7 +106,7 @@ func TestBuildDryRunReportMixedStates(t *testing.T) {
 		// test not cached
 	}
 
-	report := BuildDryRunReport(stages, cache, "hash1", false)
+	report := BuildDryRunReport(stages, cache, "hash1", false, nil)
 
 	if len(report.Stages) != 3 {
 		t.Errorf("expected 3 stages, got %d", len(report.Stages))
@@ -114,7 +114,7 @@ func TestBuildDryRunReportMixedStates(t *testing.T) {
 }
 
 func TestBuildDryRunReportSourceHash(t *testing.T) {
-	report := BuildDryRunReport(nil, nil, "abc123def", false)
+	report := BuildDryRunReport(nil, nil, "abc123def", false, nil)
 
 	if report.SourceHash != "abc123def" {
 		t.Errorf("expected source hash 'abc123def', got %q", report.SourceHash)
@@ -122,9 +122,22 @@ func TestBuildDryRunReportSourceHash(t *testing.T) {
 }
 
 func TestBuildDryRunReportEmptyStages(t *testing.T) {
-	report := BuildDryRunReport(nil, nil, "hash", false)
+	report := BuildDryRunReport(nil, nil, "hash", false, nil)
 
 	if len(report.Stages) != 0 {
 		t.Errorf("expected 0 stages, got %d", len(report.Stages))
+	}
+}
+
+func TestBuildDryRunReportRemoteTarget(t *testing.T) {
+	remote := &DryRunRemote{
+		Host:       "aivcs@discovery.local",
+		Session:    "onion",
+		WorkDir:    "/tmp/local-ci",
+		HostPreset: "discovery",
+	}
+	report := BuildDryRunReport(nil, nil, "hash", false, remote)
+	if report.Remote == nil || report.Remote.Host != "aivcs@discovery.local" {
+		t.Fatalf("expected remote target in report: %+v", report.Remote)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -413,7 +413,20 @@ func main() {
 
 	// Handle dry-run mode
 	if *flagDryRun {
-		report := BuildDryRunReport(stages, cache, sourceHash, *flagNoCache)
+		var remote *DryRunRemote
+		if *flagRemote != "" {
+			workDir := *flagRemoteDir
+			if workDir == "" {
+				workDir = filepath.Join("/tmp", filepath.Base(cwd))
+			}
+			remote = &DryRunRemote{
+				Host:       *flagRemote,
+				Session:    *flagSession,
+				WorkDir:    workDir,
+				HostPreset: *flagRemoteHost,
+			}
+		}
+		report := BuildDryRunReport(stages, cache, sourceHash, *flagNoCache, remote)
 		if *flagJSON {
 			PrintDryRunJSON(report)
 		} else {

--- a/remote.go
+++ b/remote.go
@@ -10,6 +10,48 @@ import (
 	"time"
 )
 
+// remoteSSH abstracts SSH execution so RemoteExecutor can be unit-tested
+// without a live host. When nil on RemoteExecutor, execSSH is used.
+type remoteSSH interface {
+	execWithOutput(ctx context.Context, cmd string) (string, error)
+}
+
+type execSSH struct {
+	host           string
+	connectTimeout time.Duration
+}
+
+func (e execSSH) execWithOutput(ctx context.Context, cmd string) (string, error) {
+	timeoutSec := int(e.connectTimeout.Seconds())
+	if timeoutSec < 1 {
+		timeoutSec = 10
+	}
+	sshCmd := exec.CommandContext(
+		ctx,
+		"ssh",
+		"-o",
+		fmt.Sprintf("ConnectTimeout=%d", timeoutSec),
+		e.host,
+		cmd,
+	)
+
+	var stdout, stderr bytes.Buffer
+	sshCmd.Stdout = &stdout
+	sshCmd.Stderr = &stderr
+
+	if err := sshCmd.Run(); err != nil {
+		if strings.Contains(cmd, "cat") && strings.Contains(stderr.String(), "No such file") {
+			return "", nil
+		}
+		if stderr.Len() == 0 && stdout.Len() == 0 {
+			return "", nil
+		}
+		return stdout.String(), fmt.Errorf("SSH command failed: %w (stderr: %s)", err, stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
 // RemoteExecutor handles execution of stages on a remote machine via SSH+tmux
 type RemoteExecutor struct {
 	Host    string        // SSH host (e.g., "aivcs@100.90.209.9")
@@ -17,6 +59,7 @@ type RemoteExecutor struct {
 	WorkDir string        // Remote working directory
 	Timeout time.Duration // SSH operation timeout
 	Verbose bool          // Show detailed output
+	ssh     remoteSSH     // test hook; defaults to execSSH
 }
 
 // NewRemoteExecutor creates a new remote executor
@@ -36,6 +79,35 @@ func NewRemoteExecutor(host, session, workDir string, timeout time.Duration, ver
 	}
 }
 
+func (re *RemoteExecutor) sshClient() remoteSSH {
+	if re.ssh != nil {
+		return re.ssh
+	}
+	return execSSH{host: re.Host, connectTimeout: re.Timeout}
+}
+
+// joinShellCommand quotes argv for safe remote shell execution.
+func joinShellCommand(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	quoted := make([]string, len(parts))
+	for i, p := range parts {
+		quoted[i] = escapeShellArg(p)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// buildRemoteStageCommand wraps a stage command with cd + exit-code sentinel capture.
+func buildRemoteStageCommand(workDir string, cmd []string, sentinelFile string) string {
+	return fmt.Sprintf(
+		"cd %s && %s; echo $? > %s",
+		escapeShellArg(workDir),
+		joinShellCommand(cmd),
+		sentinelFile,
+	)
+}
+
 // ExecuteStage runs a single stage on the remote machine
 func (re *RemoteExecutor) ExecuteStage(stage Stage) Result {
 	start := time.Now()
@@ -45,23 +117,16 @@ func (re *RemoteExecutor) ExecuteStage(stage Stage) Result {
 		Status:  "fail",
 	}
 
-	// Generate unique sentinel file for this stage
 	sentinelFile := fmt.Sprintf("/tmp/kc_exit_%s_%d", stage.Name, time.Now().UnixNano())
+	remoteCmd := buildRemoteStageCommand(re.WorkDir, stage.Cmd, sentinelFile)
 
-	// Build remote command with exit code capture
-	// Format: (cd /path && cmd); echo $? > /tmp/sentinel
-	remoteCmd := fmt.Sprintf(
-		"cd %s && %s; echo $? > %s",
-		escapeShellArg(re.WorkDir),
-		strings.Join(stage.Cmd, " "),
-		sentinelFile,
-	)
-
-	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(stage.Timeout)*time.Second)
+	stageTimeout := time.Duration(stage.Timeout) * time.Second
+	if stageTimeout <= 0 {
+		stageTimeout = 10 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), stageTimeout)
 	defer cancel()
 
-	// Execute command in tmux session
 	output, err := re.runInSession(ctx, remoteCmd)
 	if err != nil {
 		result.Error = err
@@ -73,7 +138,6 @@ func (re *RemoteExecutor) ExecuteStage(stage Stage) Result {
 		return result
 	}
 
-	// Poll for exit code from sentinel file
 	exitCode, err := re.pollExitCode(ctx, sentinelFile)
 	if err != nil {
 		result.Error = fmt.Errorf("failed to get exit code: %w", err)
@@ -82,10 +146,8 @@ func (re *RemoteExecutor) ExecuteStage(stage Stage) Result {
 		return result
 	}
 
-	// Cleanup sentinel file
 	_ = re.cleanupSentinel(sentinelFile)
 
-	// Update result based on exit code
 	result.Output = output
 	result.Duration = time.Since(start)
 
@@ -101,7 +163,6 @@ func (re *RemoteExecutor) ExecuteStage(stage Stage) Result {
 
 // runInSession executes a command within a tmux session
 func (re *RemoteExecutor) runInSession(ctx context.Context, cmd string) (string, error) {
-	// First, ensure the session exists and we're in the right directory
 	initCmd := fmt.Sprintf(
 		"tmux new-session -d -s %s -c %s 'sleep 999999' 2>/dev/null; true",
 		re.Session,
@@ -114,7 +175,6 @@ func (re *RemoteExecutor) runInSession(ctx context.Context, cmd string) (string,
 		}
 	}
 
-	// Send the actual command to the session
 	sendCmd := fmt.Sprintf(
 		"tmux send-keys -t %s '%s' Enter",
 		re.Session,
@@ -125,10 +185,8 @@ func (re *RemoteExecutor) runInSession(ctx context.Context, cmd string) (string,
 		return "", fmt.Errorf("failed to send command to tmux: %w", err)
 	}
 
-	// Give command time to execute, then capture output
 	time.Sleep(100 * time.Millisecond)
 
-	// Capture pane output
 	captureCmd := fmt.Sprintf("tmux capture-pane -t %s -p", re.Session)
 	output, err := re.sshExecWithOutput(ctx, captureCmd)
 	if err != nil {
@@ -140,7 +198,7 @@ func (re *RemoteExecutor) runInSession(ctx context.Context, cmd string) (string,
 
 // pollExitCode polls the remote sentinel file for the exit code
 func (re *RemoteExecutor) pollExitCode(ctx context.Context, sentinelFile string) (int, error) {
-	maxRetries := 300 // 30 seconds with 100ms poll
+	maxRetries := 300
 	retries := 0
 
 	for retries < maxRetries {
@@ -150,18 +208,15 @@ func (re *RemoteExecutor) pollExitCode(ctx context.Context, sentinelFile string)
 		default:
 		}
 
-		// Try to read exit code
 		catCmd := fmt.Sprintf("cat %s 2>/dev/null", sentinelFile)
 		output, err := re.sshExecWithOutput(ctx, catCmd)
 		if err == nil && output != "" {
-			// Successfully read exit code
 			code, err := strconv.Atoi(strings.TrimSpace(output))
 			if err == nil {
 				return code, nil
 			}
 		}
 
-		// File doesn't exist yet or couldn't read, retry
 		time.Sleep(100 * time.Millisecond)
 		retries++
 	}
@@ -171,41 +226,20 @@ func (re *RemoteExecutor) pollExitCode(ctx context.Context, sentinelFile string)
 
 // cleanupSentinel removes the sentinel file
 func (re *RemoteExecutor) cleanupSentinel(sentinelFile string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), re.Timeout)
 	defer cancel()
 
 	cleanupCmd := fmt.Sprintf("rm -f %s", sentinelFile)
 	return re.sshExec(ctx, cleanupCmd)
 }
 
-// sshExec executes a command on the remote host
 func (re *RemoteExecutor) sshExec(ctx context.Context, cmd string) error {
 	_, err := re.sshExecWithOutput(ctx, cmd)
 	return err
 }
 
-// sshExecWithOutput executes a command on the remote host and returns output
 func (re *RemoteExecutor) sshExecWithOutput(ctx context.Context, cmd string) (string, error) {
-	sshCmd := exec.CommandContext(ctx, "ssh", "-o", "ConnectTimeout=10", re.Host, cmd)
-
-	var stdout, stderr bytes.Buffer
-	sshCmd.Stdout = &stdout
-	sshCmd.Stderr = &stderr
-
-	if err := sshCmd.Run(); err != nil {
-		// For certain commands like 'cat', failure to find file is OK
-		if strings.Contains(cmd, "cat") && strings.Contains(stderr.String(), "No such file") {
-			return "", nil
-		}
-		// If there's no stderr output and no stdout, the command likely succeeded
-		// but the exit code was non-zero for a benign reason (e.g., tmux session already exists)
-		if stderr.Len() == 0 && stdout.Len() == 0 {
-			return "", nil
-		}
-		return stdout.String(), fmt.Errorf("SSH command failed: %w (stderr: %s)", err, stderr.String())
-	}
-
-	return stdout.String(), nil
+	return re.sshClient().execWithOutput(ctx, cmd)
 }
 
 // escapeShellArg safely escapes a shell argument
@@ -218,7 +252,6 @@ func escapeShellArg(arg string) string {
 
 // escapeForTmux safely escapes a command for tmux send-keys
 func escapeForTmux(cmd string) string {
-	// For tmux send-keys, we need to escape single quotes
 	return strings.ReplaceAll(cmd, "'", "'\\''")
 }
 
@@ -245,26 +278,20 @@ func (re *RemoteExecutor) TestSSHConnection(ctx context.Context) error {
 
 // SyncWorkspace uses rsync to synchronize local directory to remote WorkDir
 func (re *RemoteExecutor) SyncWorkspace(ctx context.Context, localDir string, skipDirs []string) error {
-	// 1. Ensure remote WorkDir exists
 	mkdirCmd := fmt.Sprintf("mkdir -p %s", escapeShellArg(re.WorkDir))
 	if err := re.sshExec(ctx, mkdirCmd); err != nil {
 		return fmt.Errorf("failed to create remote work directory: %w", err)
 	}
 
-	// 2. Build rsync command arguments
 	rsyncArgs := []string{"-az", "--delete"}
-
-	// Add default excludes
 	rsyncArgs = append(rsyncArgs, "--exclude", ".git", "--exclude", ".local-ci-cache")
 
-	// Add custom skipDirs from config
 	for _, dir := range skipDirs {
 		if dir != "" && dir != ".git" {
 			rsyncArgs = append(rsyncArgs, "--exclude", dir)
 		}
 	}
 
-	// Source path must end with slash to copy contents, not the directory itself
 	src := localDir
 	if !strings.HasSuffix(src, "/") {
 		src += "/"

--- a/remote_ssh.go
+++ b/remote_ssh.go
@@ -6,11 +6,13 @@ import "strings"
 type RemoteSSHDefaults struct {
 	MacOSUser      string `toml:"macos_user"`
 	LinuxSparkUser string `toml:"linux_spark_user"`
+	WindowsUser    string `toml:"windows_user"`
 }
 
 const (
 	remotePlatformMacOS      = "macos"
 	remotePlatformLinuxSpark = "linux_spark"
+	remotePlatformWindows    = "windows"
 )
 
 func (d RemoteSSHDefaults) withDefaults() RemoteSSHDefaults {
@@ -20,6 +22,9 @@ func (d RemoteSSHDefaults) withDefaults() RemoteSSHDefaults {
 	}
 	if strings.TrimSpace(out.LinuxSparkUser) == "" {
 		out.LinuxSparkUser = "aivcs2"
+	}
+	if strings.TrimSpace(out.WindowsUser) == "" {
+		out.WindowsUser = "aivcs"
 	}
 	return out
 }
@@ -33,8 +38,11 @@ func NormalizeSSHHost(host, platform string, defaults RemoteSSHDefaults) string 
 	}
 	d := defaults.withDefaults()
 	user := d.MacOSUser
-	if platform == remotePlatformLinuxSpark {
+	switch platform {
+	case remotePlatformLinuxSpark:
 		user = d.LinuxSparkUser
+	case remotePlatformWindows:
+		user = d.WindowsUser
 	}
 	return user + "@" + host
 }
@@ -47,6 +55,8 @@ func (h RemoteHost) effectivePlatform(presetName string) string {
 	switch presetName {
 	case "sparky", "aivcs2":
 		return remotePlatformLinuxSpark
+	case "msi":
+		return remotePlatformWindows
 	default:
 		return remotePlatformMacOS
 	}

--- a/remote_ssh.go
+++ b/remote_ssh.go
@@ -1,0 +1,58 @@
+package main
+
+import "strings"
+
+// RemoteSSHDefaults holds canonical SSH users for remote CI (see docs/SSH_IDENTITY.md).
+type RemoteSSHDefaults struct {
+	MacOSUser      string `toml:"macos_user"`
+	LinuxSparkUser string `toml:"linux_spark_user"`
+}
+
+const (
+	remotePlatformMacOS      = "macos"
+	remotePlatformLinuxSpark = "linux_spark"
+)
+
+func (d RemoteSSHDefaults) withDefaults() RemoteSSHDefaults {
+	out := d
+	if strings.TrimSpace(out.MacOSUser) == "" {
+		out.MacOSUser = "aivcs"
+	}
+	if strings.TrimSpace(out.LinuxSparkUser) == "" {
+		out.LinuxSparkUser = "aivcs2"
+	}
+	return out
+}
+
+// NormalizeSSHHost applies canonical users to bare Tailscale host names.
+// Explicit user@host values are returned unchanged.
+func NormalizeSSHHost(host, platform string, defaults RemoteSSHDefaults) string {
+	host = strings.TrimSpace(host)
+	if host == "" || strings.Contains(host, "@") {
+		return host
+	}
+	d := defaults.withDefaults()
+	user := d.MacOSUser
+	if platform == remotePlatformLinuxSpark {
+		user = d.LinuxSparkUser
+	}
+	return user + "@" + host
+}
+
+func (h RemoteHost) effectivePlatform(presetName string) string {
+	if p := strings.TrimSpace(h.Platform); p != "" {
+		return p
+	}
+	// Back-compat: sparky / aivcs2 presets are always the Linux Spark node.
+	switch presetName {
+	case "sparky", "aivcs2":
+		return remotePlatformLinuxSpark
+	default:
+		return remotePlatformMacOS
+	}
+}
+
+func (c *Config) normalizeRemoteHost(presetName string, h RemoteHost) RemoteHost {
+	h.Host = NormalizeSSHHost(h.Host, h.effectivePlatform(presetName), c.SSHDefaults)
+	return h
+}

--- a/remote_ssh_test.go
+++ b/remote_ssh_test.go
@@ -2,6 +2,42 @@ package main
 
 import "testing"
 
+func TestNormalizeSSHHost_BareWindows(t *testing.T) {
+	got := NormalizeSSHHost("msi", remotePlatformWindows, RemoteSSHDefaults{})
+	if got != "aivcs@msi" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestRemoteHostEffectivePlatform_MSI(t *testing.T) {
+	h := RemoteHost{}
+	if h.effectivePlatform("msi") != remotePlatformWindows {
+		t.Fatal("msi preset should imply windows")
+	}
+}
+
+func TestGetRemoteHost_NormalizesMSI(t *testing.T) {
+	dir := writeRemoteTomlWithHosts(t, `
+[ssh_defaults]
+windows_user = "aivcs"
+
+[hosts.msi]
+host = "msi"
+platform = "windows"
+`)
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := cfg.GetRemoteHost("msi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Host != "aivcs@msi" {
+		t.Fatalf("got %q", h.Host)
+	}
+}
+
 func TestNormalizeSSHHost_BareMacOS(t *testing.T) {
 	got := NormalizeSSHHost("uranus", remotePlatformMacOS, RemoteSSHDefaults{})
 	if got != "aivcs@uranus" {

--- a/remote_ssh_test.go
+++ b/remote_ssh_test.go
@@ -1,0 +1,68 @@
+package main
+
+import "testing"
+
+func TestNormalizeSSHHost_BareMacOS(t *testing.T) {
+	got := NormalizeSSHHost("uranus", remotePlatformMacOS, RemoteSSHDefaults{})
+	if got != "aivcs@uranus" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestNormalizeSSHHost_BareLinuxSpark(t *testing.T) {
+	got := NormalizeSSHHost("spark-bde7", remotePlatformLinuxSpark, RemoteSSHDefaults{})
+	if got != "aivcs2@spark-bde7" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestNormalizeSSHHost_ExplicitUserUnchanged(t *testing.T) {
+	got := NormalizeSSHHost("stevenirvin@uranus", remotePlatformMacOS, RemoteSSHDefaults{})
+	if got != "stevenirvin@uranus" {
+		t.Fatalf("explicit user must not be rewritten; got %q", got)
+	}
+}
+
+func TestNormalizeSSHHost_CustomDefaults(t *testing.T) {
+	d := RemoteSSHDefaults{MacOSUser: "bot", LinuxSparkUser: "builder"}
+	if got := NormalizeSSHHost("discovery", remotePlatformMacOS, d); got != "bot@discovery" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestRemoteHostEffectivePlatform(t *testing.T) {
+	h := RemoteHost{Platform: "linux_spark"}
+	if h.effectivePlatform("uranus") != remotePlatformLinuxSpark {
+		t.Fatal("explicit platform should win")
+	}
+	h = RemoteHost{}
+	if h.effectivePlatform("sparky") != remotePlatformLinuxSpark {
+		t.Fatal("sparky preset should imply linux_spark")
+	}
+	if h.effectivePlatform("uranus") != remotePlatformMacOS {
+		t.Fatal("default should be macos")
+	}
+}
+
+func TestGetRemoteHost_NormalizesBareHost(t *testing.T) {
+	dir := writeRemoteTomlWithHosts(t, `
+[ssh_defaults]
+macos_user = "aivcs"
+linux_spark_user = "aivcs2"
+
+[hosts.uranus]
+host = "uranus"
+platform = "macos"
+`)
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := cfg.GetRemoteHost("uranus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Host != "aivcs@uranus" {
+		t.Fatalf("got %q", h.Host)
+	}
+}

--- a/remote_test.go
+++ b/remote_test.go
@@ -254,11 +254,11 @@ func TestRemoteStageExecutionFailure(t *testing.T) {
 func TestIssue61HostPresetsDiscoveryAndUranus(t *testing.T) {
 	dir := t.TempDir()
 	example := `[hosts.discovery]
-host = "aivcs@discovery.local"
+host = "aivcs@discovery"
 
 [hosts.uranus]
-host = "aivcs@100.81.115.15"
-description = "uranus.local via Tailscale"
+host = "aivcs@uranus"
+description = "Tailscale macOS node"
 `
 	if err := os.WriteFile(filepath.Join(dir, ".local-ci-remote.toml"), []byte(example), 0644); err != nil {
 		t.Fatal(err)
@@ -283,7 +283,7 @@ description = "uranus.local via Tailscale"
 	if err != nil {
 		t.Fatal(err)
 	}
-	if discovery.Host != "aivcs@discovery.local" {
+	if discovery.Host != "aivcs@discovery" {
 		t.Errorf("discovery host: got %q", discovery.Host)
 	}
 
@@ -291,7 +291,7 @@ description = "uranus.local via Tailscale"
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uranus.Host != "aivcs@100.81.115.15" {
+	if uranus.Host != "aivcs@uranus" {
 		t.Errorf("uranus host: got %q", uranus.Host)
 	}
 }

--- a/remote_test.go
+++ b/remote_test.go
@@ -253,12 +253,18 @@ func TestRemoteStageExecutionFailure(t *testing.T) {
 
 func TestIssue61HostPresetsDiscoveryAndUranus(t *testing.T) {
 	dir := t.TempDir()
-	example := `[hosts.discovery]
-host = "aivcs@discovery"
+	example := `
+[ssh_defaults]
+macos_user = "aivcs"
+linux_spark_user = "aivcs2"
+
+[hosts.discovery]
+host = "discovery"
+platform = "macos"
 
 [hosts.uranus]
-host = "aivcs@uranus"
-description = "Tailscale macOS node"
+host = "uranus"
+platform = "macos"
 `
 	if err := os.WriteFile(filepath.Join(dir, ".local-ci-remote.toml"), []byte(example), 0644); err != nil {
 		t.Fatal(err)
@@ -279,7 +285,7 @@ description = "Tailscale macOS node"
 		}
 	}
 
-	discovery, err := cfg.ResolveRemoteHost("discovery", "", "onion", "", false, false)
+	discovery, err := cfg.GetRemoteHost("discovery")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +293,7 @@ description = "Tailscale macOS node"
 		t.Errorf("discovery host: got %q", discovery.Host)
 	}
 
-	uranus, err := cfg.ResolveRemoteHost("uranus", "", "onion", "", false, false)
+	uranus, err := cfg.GetRemoteHost("uranus")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/remote_test.go
+++ b/remote_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -30,6 +32,126 @@ func TestRemoteExecutorDefaultSession(t *testing.T) {
 	}
 }
 
+func TestJoinShellCommand(t *testing.T) {
+	tests := []struct {
+		parts []string
+		want  string
+	}{
+		{[]string{"cargo", "fmt"}, "cargo fmt"},
+		{[]string{"cargo", "clippy", "-D", "warnings"}, "cargo clippy -D warnings"},
+		{[]string{"path with spaces"}, "'path with spaces'"},
+		{[]string{"it's fine"}, "'it'\\''s fine'"},
+	}
+	for _, tc := range tests {
+		got := joinShellCommand(tc.parts)
+		if got != tc.want {
+			t.Errorf("joinShellCommand(%v): got %q want %q", tc.parts, got, tc.want)
+		}
+	}
+}
+
+func TestBuildRemoteStageCommand(t *testing.T) {
+	cmd := buildRemoteStageCommand("/data/builds/local-ci", []string{"cargo", "test", "--workspace"}, "/tmp/kc_exit_test")
+	if !strings.Contains(cmd, "cd /data/builds/local-ci") {
+		t.Fatalf("missing cd: %q", cmd)
+	}
+	if !strings.Contains(cmd, "cargo test --workspace") {
+		t.Fatalf("missing command: %q", cmd)
+	}
+	if !strings.Contains(cmd, "echo $? > /tmp/kc_exit_test") {
+		t.Fatalf("missing sentinel: %q", cmd)
+	}
+}
+
+type mockSSH struct {
+	calls    []string
+	exitCode string
+	failOn   string
+}
+
+func (m *mockSSH) execWithOutput(_ context.Context, cmd string) (string, error) {
+	m.calls = append(m.calls, cmd)
+	if m.failOn != "" && strings.Contains(cmd, m.failOn) {
+		return "", context.DeadlineExceeded
+	}
+	if strings.Contains(cmd, "capture-pane") {
+		return "stage output\n", nil
+	}
+	if strings.Contains(cmd, "cat /tmp/kc_exit_") {
+		if m.exitCode != "" {
+			return m.exitCode, nil
+		}
+		return "", nil
+	}
+	return "", nil
+}
+
+func TestRemoteExecutorExecuteStageSuccess(t *testing.T) {
+	mock := &mockSSH{exitCode: "0\n"}
+	re := NewRemoteExecutor("aivcs@test", "onion", "/tmp/project", 30*time.Second, false)
+	re.ssh = mock
+
+	stage := Stage{
+		Name:    "fmt",
+		Cmd:     []string{"echo", "hello"},
+		Timeout: 5,
+		Enabled: true,
+	}
+
+	result := re.ExecuteStage(stage)
+	if result.Status != "pass" {
+		t.Fatalf("expected pass, got %s (%v)", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Output, "stage output") {
+		t.Errorf("expected captured output, got %q", result.Output)
+	}
+	if len(mock.calls) == 0 {
+		t.Fatal("expected SSH calls")
+	}
+}
+
+func TestRemoteExecutorExecuteStageFailure(t *testing.T) {
+	mock := &mockSSH{exitCode: "42\n"}
+	re := NewRemoteExecutor("aivcs@test", "onion", "/tmp/project", 30*time.Second, false)
+	re.ssh = mock
+
+	stage := Stage{
+		Name:    "test",
+		Cmd:     []string{"false"},
+		Timeout: 5,
+		Enabled: true,
+	}
+
+	result := re.ExecuteStage(stage)
+	if result.Status != "fail" {
+		t.Fatalf("expected fail, got %s", result.Status)
+	}
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "42") {
+		t.Fatalf("expected exit code 42 error, got %v", result.Error)
+	}
+}
+
+func TestRemoteExecutorSSHFailure(t *testing.T) {
+	mock := &mockSSH{failOn: "send-keys"}
+	re := NewRemoteExecutor("aivcs@test", "onion", "/tmp/project", 30*time.Second, false)
+	re.ssh = mock
+
+	stage := Stage{
+		Name:    "fmt",
+		Cmd:     []string{"echo", "hello"},
+		Timeout: 5,
+		Enabled: true,
+	}
+
+	result := re.ExecuteStage(stage)
+	if result.Status != "fail" {
+		t.Fatalf("expected fail, got %s", result.Status)
+	}
+	if result.Error == nil {
+		t.Fatal("expected SSH error")
+	}
+}
+
 func TestEscapeShellArg(t *testing.T) {
 	tests := map[string]string{
 		"/simple/path":      "/simple/path",
@@ -39,7 +161,6 @@ func TestEscapeShellArg(t *testing.T) {
 
 	for input, _ := range tests {
 		result := escapeShellArg(input)
-		// Just verify it doesn't crash and returns something
 		if len(result) == 0 {
 			t.Errorf("escapeShellArg(%q) returned empty string", input)
 		}
@@ -62,13 +183,10 @@ func TestEscapeForTmux(t *testing.T) {
 }
 
 func TestRemoteStageExecution(t *testing.T) {
-	// This test requires actual SSH access to aivcs@100.90.209.9
-	// Skip if not available
 	t.Skip("Integration test - requires SSH access to aivcs@100.90.209.9")
 
 	re := NewRemoteExecutor("aivcs@100.90.209.9", "test-session", "/tmp", 30*time.Second, true)
 
-	// Test SSH connection
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	err := re.TestSSHConnection(ctx)
 	cancel()
@@ -76,7 +194,6 @@ func TestRemoteStageExecution(t *testing.T) {
 		t.Skipf("Cannot connect to remote host: %v", err)
 	}
 
-	// Test session creation
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	err = re.EnsureRemoteSession(ctx)
 	cancel()
@@ -85,7 +202,6 @@ func TestRemoteStageExecution(t *testing.T) {
 		return
 	}
 
-	// Test simple command execution
 	stage := Stage{
 		Name:    "test",
 		Cmd:     []string{"echo", "hello"},
@@ -101,14 +217,12 @@ func TestRemoteStageExecution(t *testing.T) {
 		t.Errorf("Expected output to contain 'hello', got %q", result.Output)
 	}
 
-	// Cleanup
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	_ = re.KillRemoteSession(ctx)
 	cancel()
 }
 
 func TestRemoteStageExecutionFailure(t *testing.T) {
-	// This test requires actual SSH access
 	t.Skip("Integration test - requires SSH access to aivcs@100.90.209.9")
 
 	re := NewRemoteExecutor("aivcs@100.90.209.9", "test-session-fail", "/tmp", 30*time.Second, false)
@@ -117,7 +231,6 @@ func TestRemoteStageExecutionFailure(t *testing.T) {
 	_ = re.TestSSHConnection(ctx)
 	cancel()
 
-	// Test command that fails
 	stage := Stage{
 		Name:    "failing-test",
 		Cmd:     []string{"sh", "-c", "exit 42"},
@@ -133,8 +246,52 @@ func TestRemoteStageExecutionFailure(t *testing.T) {
 		t.Errorf("Expected error, got nil")
 	}
 
-	// Cleanup
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	_ = re.KillRemoteSession(ctx)
 	cancel()
+}
+
+func TestIssue61HostPresetsDiscoveryAndUranus(t *testing.T) {
+	dir := t.TempDir()
+	example := `[hosts.discovery]
+host = "aivcs@discovery.local"
+
+[hosts.uranus]
+host = "aivcs@100.81.115.15"
+description = "uranus.local via Tailscale"
+`
+	if err := os.WriteFile(filepath.Join(dir, ".local-ci-remote.toml"), []byte(example), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"discovery", "uranus"} {
+		h, err := cfg.GetRemoteHost(name)
+		if err != nil {
+			t.Fatalf("GetRemoteHost(%q): %v", name, err)
+		}
+		if h.Host == "" {
+			t.Fatalf("preset %q has empty host", name)
+		}
+	}
+
+	discovery, err := cfg.ResolveRemoteHost("discovery", "", "onion", "", false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if discovery.Host != "aivcs@discovery.local" {
+		t.Errorf("discovery host: got %q", discovery.Host)
+	}
+
+	uranus, err := cfg.ResolveRemoteHost("uranus", "", "onion", "", false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uranus.Host != "aivcs@100.81.115.15" {
+		t.Errorf("uranus host: got %q", uranus.Host)
+	}
 }


### PR DESCRIPTION
## Summary

Completes [issue #61](https://github.com/stevedores-org/local-ci/issues/61) — remote execution via SSH+tmux for expensive **pre-push** stages on tailnet nodes (avoids slow/costly GitHub Actions iteration).

Builds on #62–#64 (remote flags, rsync workspace sync, `--remote-host` presets).

### Code
- Mock SSH unit tests (pass / fail / connection error)
- Safe shell quoting (`joinShellCommand`, `buildRemoteStageCommand`)
- `--remote-timeout` → SSH `ConnectTimeout`
- Dry-run remote metadata (`--dry-run --remote-host …`)
- `[ssh_defaults]` + platform-aware host normalization (`macos` / `linux_spark` / `windows`)

### Docs
- [`docs/SSH_IDENTITY.md`](docs/SSH_IDENTITY.md) — fleet **in Tailscale** (`downhome` local Mac, `uranus`, `discovery`, `spark-bde7`, `msi`)
- Updated README, `REMOTE_CI_SETUP.md`, `.local-ci-remote.toml.example`

## Usage

```bash
tailscale status
local-ci                                    # on downhome
local-ci --remote-host uranus fmt clippy test
local-ci --remote-host sparky test          # aivcs2@spark-bde7
local-ci --remote-host msi --dry-run        # aivcs@msi (Windows + RTX 5070)
local-ci --list-remote-hosts
```

## Test plan

- [x] `go test ./...` (CI)
- [x] `gofmt` / Nix flake check (CI)
- [ ] Operator smoke: `--remote-host uranus` or `sparky` against live tailnet node
- [ ] Operator: SSH key on `msi` for Windows remote path (WSL + tmux)

Closes #61