### PR TITLE
Fix cache, parallel, and remote execution bugs

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,28 @@
+package main
+
+import "strings"
+
+// cacheKeyForStage builds the canonical cache entry value: "<hash>|<command>".
+func cacheKeyForStage(stage Stage, hash string) string {
+	if hash == "" {
+		return ""
+	}
+	return hash + "|" + strings.Join(stage.Cmd, " ")
+}
+
+// cacheHit reports whether the stage is cached for the given content hash.
+// Legacy entries stored as hash-only (without "|command") still match.
+func cacheHit(cache map[string]string, stage Stage, hash string) bool {
+	if hash == "" {
+		return false
+	}
+	entry, ok := cache[stage.Name]
+	if !ok {
+		return false
+	}
+	key := cacheKeyForStage(stage, hash)
+	if entry == key {
+		return true
+	}
+	return entry == hash
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func TestCacheKeyForStage(t *testing.T) {
+	stage := Stage{Name: "fmt", Cmd: []string{"cargo", "fmt"}}
+	got := cacheKeyForStage(stage, "abc123")
+	want := "abc123|cargo fmt"
+	if got != want {
+		t.Fatalf("cacheKeyForStage = %q, want %q", got, want)
+	}
+}
+
+func TestCacheHitCanonicalAndLegacy(t *testing.T) {
+	stage := Stage{Name: "fmt", Cmd: []string{"cargo", "fmt"}}
+	cache := map[string]string{
+		"fmt": cacheKeyForStage(stage, "abc123"),
+	}
+	if !cacheHit(cache, stage, "abc123") {
+		t.Fatal("expected canonical cache hit")
+	}
+
+	legacy := map[string]string{"fmt": "abc123"}
+	if !cacheHit(legacy, stage, "abc123") {
+		t.Fatal("expected legacy hash-only cache hit")
+	}
+}
+
+func TestCacheHitMiss(t *testing.T) {
+	stage := Stage{Name: "fmt", Cmd: []string{"cargo", "fmt"}}
+	cache := map[string]string{"fmt": cacheKeyForStage(stage, "old")}
+	if cacheHit(cache, stage, "new") {
+		t.Fatal("expected cache miss")
+	}
+}

--- a/dryrun.go
+++ b/dryrun.go
@@ -32,7 +32,7 @@ type DryRunReport struct {
 }
 
 // BuildDryRunReport creates a dry-run report for the given stages
-func BuildDryRunReport(stages []Stage, cache map[string]string, sourceHash string, noCache bool, remote *DryRunRemote) DryRunReport {
+func BuildDryRunReport(stages []Stage, cache map[string]string, stageHashes map[string]string, sourceHash string, noCache bool, remote *DryRunRemote) DryRunReport {
 	workspace, _ := os.Getwd()
 
 	var dryRunStages []DryRunStage
@@ -42,13 +42,20 @@ func BuildDryRunReport(stages []Stage, cache map[string]string, sourceHash strin
 			Command: strings.Join(stage.Cmd, " "),
 		}
 
+		hash := sourceHash
+		if stageHashes != nil {
+			if h, ok := stageHashes[stage.Name]; ok {
+				hash = h
+			}
+		}
+
 		if !stage.Enabled {
 			dryRunStage.WouldRun = false
 			dryRunStage.Reason = "disabled"
 		} else if noCache {
 			dryRunStage.WouldRun = true
 			dryRunStage.Reason = "no_cache_flag"
-		} else if cache[stage.Name] == sourceHash {
+		} else if cacheHit(cache, stage, hash) {
 			dryRunStage.WouldRun = false
 			dryRunStage.Reason = "cached"
 		} else {

--- a/dryrun_test.go
+++ b/dryrun_test.go
@@ -15,7 +15,7 @@ func TestBuildDryRunReportAllCached(t *testing.T) {
 		"test": "hash1",
 	}
 
-	report := BuildDryRunReport(stages, cache, "hash1", false, nil)
+	report := BuildDryRunReport(stages, cache, nil, "hash1", false, nil)
 
 	for _, s := range report.Stages {
 		if s.WouldRun {
@@ -38,7 +38,7 @@ func TestBuildDryRunReportHashChanged(t *testing.T) {
 		"test": "oldhash",
 	}
 
-	report := BuildDryRunReport(stages, cache, "newhash", false, nil)
+	report := BuildDryRunReport(stages, cache, nil, "newhash", false, nil)
 
 	for _, s := range report.Stages {
 		if !s.WouldRun {
@@ -59,7 +59,7 @@ func TestBuildDryRunReportNoCache(t *testing.T) {
 		"fmt": "hash1",
 	}
 
-	report := BuildDryRunReport(stages, cache, "hash1", true, nil)
+	report := BuildDryRunReport(stages, cache, nil, "hash1", true, nil)
 
 	if len(report.Stages) != 1 {
 		t.Fatalf("expected 1 stage, got %d", len(report.Stages))
@@ -78,7 +78,7 @@ func TestBuildDryRunReportDisabledStages(t *testing.T) {
 		{Name: "deny", Cmd: []string{"cargo", "deny"}, Enabled: false},
 	}
 
-	report := BuildDryRunReport(stages, nil, "hash1", true, nil)
+	report := BuildDryRunReport(stages, nil, nil, "hash1", true, nil)
 
 	disabledCount := 0
 	for _, s := range report.Stages {
@@ -106,7 +106,7 @@ func TestBuildDryRunReportMixedStates(t *testing.T) {
 		// test not cached
 	}
 
-	report := BuildDryRunReport(stages, cache, "hash1", false, nil)
+	report := BuildDryRunReport(stages, cache, nil, "hash1", false, nil)
 
 	if len(report.Stages) != 3 {
 		t.Errorf("expected 3 stages, got %d", len(report.Stages))
@@ -114,7 +114,7 @@ func TestBuildDryRunReportMixedStates(t *testing.T) {
 }
 
 func TestBuildDryRunReportSourceHash(t *testing.T) {
-	report := BuildDryRunReport(nil, nil, "abc123def", false, nil)
+	report := BuildDryRunReport(nil, nil, nil, "abc123def", false, nil)
 
 	if report.SourceHash != "abc123def" {
 		t.Errorf("expected source hash 'abc123def', got %q", report.SourceHash)
@@ -122,7 +122,7 @@ func TestBuildDryRunReportSourceHash(t *testing.T) {
 }
 
 func TestBuildDryRunReportEmptyStages(t *testing.T) {
-	report := BuildDryRunReport(nil, nil, "hash", false, nil)
+	report := BuildDryRunReport(nil, nil, nil, "hash", false, nil)
 
 	if len(report.Stages) != 0 {
 		t.Errorf("expected 0 stages, got %d", len(report.Stages))
@@ -136,7 +136,7 @@ func TestBuildDryRunReportRemoteTarget(t *testing.T) {
 		WorkDir:    "/tmp/local-ci",
 		HostPreset: "discovery",
 	}
-	report := BuildDryRunReport(nil, nil, "hash", false, remote)
+	report := BuildDryRunReport(nil, nil, nil, "hash", false, remote)
 	if report.Remote == nil || report.Remote.Host != "aivcs@discovery" {
 		t.Fatalf("expected remote target in report: %+v", report.Remote)
 	}

--- a/main.go
+++ b/main.go
@@ -239,11 +239,6 @@ func main() {
 			return
 		}
 	}
-	if len(args) > 0 && args[0] == "serve" {
-		if err := cmdServe(cwd); err != nil {
-			fatalf("MCP server error: %v", err)
-		}
-	}
 
 	// Load configuration. Pull the remote overlay whenever remote mode or
 	// preset listing is requested — `--remote-host` resolves [hosts.*].
@@ -304,6 +299,11 @@ func main() {
 		if *flagVerbose {
 			printf("📍 Using host preset %q → %s\n", *flagRemoteHost, *flagRemote)
 		}
+	}
+
+	// Expand bare `--remote discovery` hostnames via ssh_defaults (macOS default).
+	if *flagRemote != "" && !strings.Contains(*flagRemote, "@") {
+		*flagRemote = NormalizeSSHHost(*flagRemote, remotePlatformMacOS, config.SSHDefaults)
 	}
 
 	// Apply profile if specified
@@ -377,9 +377,16 @@ func main() {
 
 	// If --all, include disabled stages
 	if *flagAll {
-		for _, stage := range stages {
-			if !stage.Enabled {
+		if len(flag.Args()) == 0 {
+			stages = stages[:0]
+			for name, stage := range stageMap {
+				stage.Name = name
 				stage.Enabled = true
+				stages = append(stages, stage)
+			}
+		} else {
+			for i := range stages {
+				stages[i].Enabled = true
 			}
 		}
 	}
@@ -411,6 +418,11 @@ func main() {
 		cache = make(map[string]string)
 	}
 
+	stageHashes, stageHashErr := computeStageHashes(cwd, config, ws, stages)
+	if stageHashErr != nil && *flagVerbose {
+		warnf("Warning: per-stage hash computation failed: %v\n", stageHashErr)
+	}
+
 	// Handle dry-run mode
 	if *flagDryRun {
 		var remote *DryRunRemote
@@ -426,7 +438,7 @@ func main() {
 				HostPreset: *flagRemoteHost,
 			}
 		}
-		report := BuildDryRunReport(stages, cache, sourceHash, *flagNoCache, remote)
+		report := BuildDryRunReport(stages, cache, stageHashes, sourceHash, *flagNoCache, remote)
 		if *flagJSON {
 			PrintDryRunJSON(report)
 		} else {
@@ -441,6 +453,9 @@ func main() {
 
 	// Use parallel runner if requested
 	if *flagParallel > 0 {
+		if *flagRemote != "" {
+			fatalf("Cannot use --parallel and --remote together; run remote stages sequentially")
+		}
 		runner := &ParallelRunner{
 			Stages:      stages,
 			Concurrency: *flagParallel,
@@ -448,6 +463,7 @@ func main() {
 			NoCache:     *flagNoCache,
 			Cache:       cache,
 			SourceHash:  sourceHash,
+			StageHashes: stageHashes,
 			Verbose:     *flagVerbose,
 			JSON:        *flagJSON,
 			FailFast:    *flagFailFast,
@@ -486,15 +502,22 @@ func main() {
 			// Compute per-stage hash for granular caching
 			stageHash := sourceHash
 			if len(stage.Watch) > 0 {
-				var err error
-				stageHash, err = computeStageHash(stage, cwd, config, ws)
-				if err != nil && *flagVerbose {
-					warnf("Stage hash computation failed for %s: %v\n", stage.Name, err)
+				if h, ok := stageHashes[stage.Name]; ok {
+					stageHash = h
+				} else {
+					var err error
+					stageHash, err = computeStageHash(stage, cwd, config, ws)
+					if err != nil {
+						if *flagVerbose {
+							warnf("Stage hash computation failed for %s: %v\n", stage.Name, err)
+						}
+						stageHash = ""
+					}
 				}
 			}
 
 			// Check local cache
-			if !*flagNoCache && cache[stage.Name] == stageHash {
+			if !*flagNoCache && cacheHit(cache, stage, stageHash) {
 				if *flagVerbose {
 					printf("✓ %s (cached)\n", stage.Name)
 				}
@@ -509,6 +532,21 @@ func main() {
 
 			// Print stage header
 			printf("::group::%s\n", stage.Name)
+			if len(stage.Cmd) == 0 {
+				printf("Error: Stage has no command defined\n")
+				printf("::endgroup::\n")
+				printf("✗ %s (failed)\n", stage.Name)
+				results = append(results, Result{
+					Name:     stage.Name,
+					Status:   "fail",
+					Duration: 0,
+					Error:    fmt.Errorf("no command defined"),
+				})
+				if *flagFailFast {
+					break
+				}
+				continue
+			}
 			if *flagVerbose {
 				cmdStr := strings.Join(stage.Cmd, " ")
 				printf("$ %s\n", cmdStr)
@@ -539,7 +577,7 @@ func main() {
 				printf("✓ %s (%dms)\n", stage.Name, result.Duration.Milliseconds())
 				results = append(results, result)
 				// Update cache
-				cache[stage.Name] = stageHash
+				cache[stage.Name] = cacheKeyForStage(stage, stageHash)
 			}
 		}
 	} else {
@@ -552,15 +590,22 @@ func main() {
 			// Compute per-stage hash for granular caching
 			stageHash := sourceHash
 			if len(stage.Watch) > 0 {
-				var err error
-				stageHash, err = computeStageHash(stage, cwd, config, ws)
-				if err != nil && *flagVerbose {
-					warnf("Stage hash computation failed for %s: %v\n", stage.Name, err)
+				if h, ok := stageHashes[stage.Name]; ok {
+					stageHash = h
+				} else {
+					var err error
+					stageHash, err = computeStageHash(stage, cwd, config, ws)
+					if err != nil {
+						if *flagVerbose {
+							warnf("Stage hash computation failed for %s: %v\n", stage.Name, err)
+						}
+						stageHash = ""
+					}
 				}
 			}
 
 			// Check cache using per-stage hash
-			if !*flagNoCache && cache[stage.Name] == stageHash {
+			if !*flagNoCache && cacheHit(cache, stage, stageHash) {
 				if *flagVerbose {
 					printf("✓ %s (cached)\n", stage.Name)
 				}
@@ -637,7 +682,7 @@ func main() {
 					Output:   out.String(),
 				})
 				// Update cache with per-stage hash
-				cache[stage.Name] = stageHash
+				cache[stage.Name] = cacheKeyForStage(stage, stageHash)
 			}
 		}
 	}
@@ -773,19 +818,7 @@ func computeSourceHash(root string, config *Config, ws *Workspace) (string, erro
 
 		// Hash files matching include patterns
 		if !d.IsDir() {
-			shouldHash := false
-			for _, pattern := range config.Cache.IncludePatterns {
-				// Simple pattern matching: *.rs, *.toml
-				if strings.HasPrefix(pattern, "*.") {
-					ext := pattern[1:] // Get .rs or .toml
-					if strings.HasSuffix(d.Name(), ext) {
-						shouldHash = true
-						break
-					}
-				}
-			}
-
-			if shouldHash {
+			if matchesPatterns(d.Name(), config.Cache.IncludePatterns) {
 				data, err := os.ReadFile(path)
 				if err != nil {
 					return nil // Skip unreadable files
@@ -844,27 +877,7 @@ func computeStageHash(stage Stage, root string, config *Config, ws *Workspace) (
 
 		// Hash files matching watch patterns
 		if !d.IsDir() {
-			shouldHash := false
-			for _, pattern := range stage.Watch {
-				// Simple pattern matching: *.rs, *.toml
-				if strings.HasPrefix(pattern, "*.") {
-					ext := pattern[1:] // Get .rs or .toml
-					if strings.HasSuffix(d.Name(), ext) {
-						shouldHash = true
-						break
-					}
-				} else if pattern == "*" {
-					// Match all files
-					shouldHash = true
-					break
-				} else if d.Name() == pattern {
-					// Exact filename match
-					shouldHash = true
-					break
-				}
-			}
-
-			if shouldHash {
+			if matchesPatterns(d.Name(), stage.Watch) {
 				data, err := os.ReadFile(path)
 				if err != nil {
 					return nil // Skip unreadable files
@@ -898,7 +911,7 @@ func loadCache(root string) (map[string]string, error) {
 		if line == "" {
 			continue
 		}
-		parts := strings.Split(line, ":")
+		parts := strings.SplitN(line, ":", 2)
 		if len(parts) == 2 {
 			cache[parts[0]] = parts[1]
 		}

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -107,8 +107,14 @@ func (mc *mcpContext) handleRunAll(ctx context.Context, _ mcp.CallToolRequest) (
 	return mc.resultsToMCP(results), nil
 }
 
+func (mc *mcpContext) stageHash(stage Stage) (string, error) {
+	if len(stage.Watch) > 0 {
+		return computeStageHash(stage, mc.root, mc.config, mc.ws)
+	}
+	return computeSourceHash(mc.root, mc.config, mc.ws)
+}
+
 func (mc *mcpContext) handleGetStages(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	hash, _ := computeSourceHash(mc.root, mc.config, mc.ws)
 	cache, _ := loadCache(mc.root)
 
 	type stageInfo struct {
@@ -120,9 +126,10 @@ func (mc *mcpContext) handleGetStages(_ context.Context, _ mcp.CallToolRequest) 
 
 	var stages []stageInfo
 	for name, stage := range mc.config.Stages {
+		stage.Name = name
 		cmdStr := strings.Join(stage.Cmd, " ")
-		cacheKey := hash + "|" + cmdStr
-		hit := cache[name] == cacheKey
+		hash, _ := mc.stageHash(stage)
+		hit := cacheHit(cache, stage, hash)
 		stages = append(stages, stageInfo{
 			Name:     name,
 			Enabled:  stage.Enabled,
@@ -136,7 +143,6 @@ func (mc *mcpContext) handleGetStages(_ context.Context, _ mcp.CallToolRequest) 
 }
 
 func (mc *mcpContext) handleGetStaleStages(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	hash, _ := computeSourceHash(mc.root, mc.config, mc.ws)
 	cache, _ := loadCache(mc.root)
 
 	type staleStage struct {
@@ -149,9 +155,9 @@ func (mc *mcpContext) handleGetStaleStages(_ context.Context, _ mcp.CallToolRequ
 		if !stage.Enabled {
 			continue
 		}
-		cmdStr := strings.Join(stage.Cmd, " ")
-		cacheKey := hash + "|" + cmdStr
-		if cache[name] != cacheKey {
+		stage.Name = name
+		hash, _ := mc.stageHash(stage)
+		if !cacheHit(cache, stage, hash) {
 			reason := "cache miss"
 			if _, exists := cache[name]; !exists {
 				reason = "never run"
@@ -237,11 +243,18 @@ func (mc *mcpContext) handleGetWorkspace(_ context.Context, _ mcp.CallToolReques
 func (mc *mcpContext) executeStage(parent context.Context, stage Stage) Result {
 	cmdStr := strings.Join(stage.Cmd, " ")
 
-	// Check cache
-	hash, _ := computeSourceHash(mc.root, mc.config, mc.ws)
+	if len(stage.Cmd) == 0 {
+		return Result{
+			Name:    stage.Name,
+			Command: cmdStr,
+			Status:  "fail",
+			Error:   fmt.Errorf("no command defined"),
+		}
+	}
+
+	hash, _ := mc.stageHash(stage)
 	cache, _ := loadCache(mc.root)
-	cacheKey := hash + "|" + cmdStr
-	if cache[stage.Name] == cacheKey {
+	if cacheHit(cache, stage, hash) {
 		return Result{
 			Name:     stage.Name,
 			Command:  cmdStr,
@@ -278,8 +291,7 @@ func (mc *mcpContext) executeStage(parent context.Context, stage Stage) Result {
 		result.Error = err
 	} else {
 		result.Status = "pass"
-		// Update cache on success
-		cache[stage.Name] = cacheKey
+		cache[stage.Name] = cacheKeyForStage(stage, hash)
 		_ = saveCache(cache, mc.root)
 	}
 

--- a/parallel.go
+++ b/parallel.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os/exec"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -25,35 +27,30 @@ type ParallelRunner struct {
 
 // Run executes all stages concurrently with dependency management
 func (r *ParallelRunner) Run() []Result {
-	// Adjust concurrency
 	if r.Concurrency <= 0 {
 		r.Concurrency = runtime.NumCPU()
 	}
 
-	// Create a semaphore to limit concurrent executions
 	sem := make(chan struct{}, r.Concurrency)
-
-	// Track stage completion for dependency resolution
 	completed := make(map[string]bool)
 	var mu sync.Mutex
+	var failed atomic.Bool
 
-	// Result channel for collecting results
 	resultChan := make(chan Result, len(r.Stages))
 	var wg sync.WaitGroup
 
-	// Build dependency graph
 	stageDeps := make(map[string][]string)
-	for _, stage := range r.Stages {
+	stageIndex := make(map[string]int, len(r.Stages))
+	for i, stage := range r.Stages {
 		stageDeps[stage.Name] = stage.DependsOn
+		stageIndex[stage.Name] = i
 	}
 
-	// Process each stage
 	for _, stage := range r.Stages {
 		wg.Add(1)
 		go func(s Stage) {
 			defer wg.Done()
 
-			// Wait for dependencies
 			for {
 				mu.Lock()
 				allDone := true
@@ -63,54 +60,67 @@ func (r *ParallelRunner) Run() []Result {
 						break
 					}
 				}
+				if allDone && r.FailFast {
+					myIdx := stageIndex[s.Name]
+					for _, earlier := range r.Stages {
+						if stageIndex[earlier.Name] >= myIdx {
+							break
+						}
+						if !completed[earlier.Name] {
+							allDone = false
+							break
+						}
+					}
+				}
 				mu.Unlock()
-
 				if allDone {
 					break
 				}
 				time.Sleep(10 * time.Millisecond)
 			}
 
-			// Check fail-fast flag
-			if r.FailFast {
-				mu.Lock()
-				if len(resultChan) > 0 {
-					// Check if any result is a failure
-					for result := range resultChan {
-						if result.Status != "pass" {
-							mu.Unlock()
-							mu.Lock()
-							completed[s.Name] = true
-							mu.Unlock()
-							resultChan <- result // Put it back
-							return
-						}
-						resultChan <- result // Put it back
-					}
+			skip := func() {
+				resultChan <- Result{
+					Name:   s.Name,
+					Status: "skip",
 				}
+				mu.Lock()
+				completed[s.Name] = true
 				mu.Unlock()
 			}
 
-			// Acquire semaphore
+			if r.FailFast && failed.Load() {
+				skip()
+				return
+			}
+
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			// Execute stage
+			if r.FailFast && failed.Load() {
+				skip()
+				return
+			}
+
 			result := r.executeStage(s)
+			if result.Status != "pass" {
+				failed.Store(true)
+			} else if !result.CacheHit {
+				mu.Lock()
+				r.Cache[s.Name] = cacheKeyForStage(s, r.stageHash(s))
+				mu.Unlock()
+			}
 			resultChan <- result
 
-			// Mark as completed
 			mu.Lock()
 			completed[s.Name] = true
 			mu.Unlock()
 		}(stage)
 	}
 
-	// Wait for all goroutines to complete
 	wg.Wait()
 	close(resultChan)
 
-	// Collect results in order
 	resultMap := make(map[string]Result)
 	for result := range resultChan {
 		resultMap[result.Name] = result
@@ -126,12 +136,21 @@ func (r *ParallelRunner) Run() []Result {
 	return results
 }
 
+func (r *ParallelRunner) stageHash(stage Stage) string {
+	if r.StageHashes != nil {
+		if h, ok := r.StageHashes[stage.Name]; ok {
+			return h
+		}
+	}
+	return r.SourceHash
+}
+
 // executeStage runs a single stage
 func (r *ParallelRunner) executeStage(stage Stage) Result {
 	stageStart := time.Now()
+	hash := r.stageHash(stage)
 
-	// Check cache
-	if !r.NoCache && r.Cache[stage.Name] == r.SourceHash {
+	if !r.NoCache && cacheHit(r.Cache, stage, hash) {
 		return Result{
 			Name:     stage.Name,
 			Status:   "pass",
@@ -140,7 +159,15 @@ func (r *ParallelRunner) executeStage(stage Stage) Result {
 		}
 	}
 
-	// Create context with timeout
+	if len(stage.Cmd) == 0 {
+		return Result{
+			Name:     stage.Name,
+			Status:   "fail",
+			Duration: time.Since(stageStart),
+			Error:    fmt.Errorf("no command defined"),
+		}
+	}
+
 	timeout := time.Duration(stage.Timeout) * time.Second
 	if timeout == 0 {
 		timeout = 30 * time.Second
@@ -149,7 +176,6 @@ func (r *ParallelRunner) executeStage(stage Stage) Result {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// Execute command
 	cmd := exec.CommandContext(ctx, stage.Cmd[0], stage.Cmd[1:]...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -168,8 +194,6 @@ func (r *ParallelRunner) executeStage(stage Stage) Result {
 			Output:   out.String(),
 		}
 	}
-
-	// Note: cache update is done by the caller after collecting results
 
 	return Result{
 		Name:     stage.Name,

--- a/parallel_deadlock_test.go
+++ b/parallel_deadlock_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParallelRunnerFailFastPassingDeadlock(t *testing.T) {
+	dir := t.TempDir()
+	stages := []Stage{
+		{Name: "s1", Cmd: []string{"echo", "1"}, Timeout: 10},
+		{Name: "s2", Cmd: []string{"echo", "2"}, Timeout: 10},
+	}
+	pr := &ParallelRunner{
+		Stages: stages, Concurrency: 1, Cwd: dir, NoCache: true,
+		Cache: map[string]string{}, SourceHash: "h", FailFast: true,
+	}
+	done := make(chan struct{})
+	go func() { pr.Run(); close(done) }()
+	select {
+	case <-done:
+		// expected: fail-fast must not deadlock when all stages pass
+	case <-time.After(2 * time.Second):
+		t.Fatal("parallel fail-fast hung with all-passing stages")
+	}
+}

--- a/parallel_ff_test.go
+++ b/parallel_ff_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParallelFailFastIndependentStagesStillRun(t *testing.T) {
+	dir := t.TempDir()
+	stages := []Stage{
+		{Name: "fail", Cmd: []string{"false"}, Timeout: 10},
+		{Name: "second", Cmd: []string{"echo", "ran"}, Timeout: 10},
+	}
+	pr := &ParallelRunner{
+		Stages: stages, Concurrency: 1, Cwd: dir, NoCache: true,
+		Cache: map[string]string{}, SourceHash: "h", FailFast: true,
+	}
+	results := pr.Run()
+	for _, r := range results {
+		if r.Name == "second" {
+			if r.Status == "pass" && strings.Contains(r.Output, "ran") {
+				t.Fatal("fail-fast should prevent second independent stage from running")
+			}
+		}
+	}
+}

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -112,7 +112,7 @@ func TestParallelRunnerCacheHit(t *testing.T) {
 	}
 
 	cache := map[string]string{
-		"cached": "hash123",
+		"cached": cacheKeyForStage(Stage{Name: "cached", Cmd: []string{"echo", "hello"}}, "hash123"),
 	}
 
 	pr := &ParallelRunner{

--- a/remote.go
+++ b/remote.go
@@ -40,13 +40,11 @@ func (e execSSH) execWithOutput(ctx context.Context, cmd string) (string, error)
 	sshCmd.Stderr = &stderr
 
 	if err := sshCmd.Run(); err != nil {
-		if strings.Contains(cmd, "cat") && strings.Contains(stderr.String(), "No such file") {
+		stderrStr := stderr.String()
+		if strings.Contains(cmd, "cat") && (strings.Contains(stderrStr, "No such file") || strings.Contains(stderrStr, "cannot open")) {
 			return "", nil
 		}
-		if stderr.Len() == 0 && stdout.Len() == 0 {
-			return "", nil
-		}
-		return stdout.String(), fmt.Errorf("SSH command failed: %w (stderr: %s)", err, stderr.String())
+		return stdout.String(), fmt.Errorf("SSH command failed: %w (stderr: %s)", err, stderrStr)
 	}
 
 	return stdout.String(), nil
@@ -117,6 +115,12 @@ func (re *RemoteExecutor) ExecuteStage(stage Stage) Result {
 		Status:  "fail",
 	}
 
+	if len(stage.Cmd) == 0 {
+		result.Error = fmt.Errorf("no command defined")
+		result.Duration = time.Since(start)
+		return result
+	}
+
 	sentinelFile := fmt.Sprintf("/tmp/kc_exit_%s_%d", stage.Name, time.Now().UnixNano())
 	remoteCmd := buildRemoteStageCommand(re.WorkDir, stage.Cmd, sentinelFile)
 
@@ -127,10 +131,8 @@ func (re *RemoteExecutor) ExecuteStage(stage Stage) Result {
 	ctx, cancel := context.WithTimeout(context.Background(), stageTimeout)
 	defer cancel()
 
-	output, err := re.runInSession(ctx, remoteCmd)
-	if err != nil {
+	if err := re.sendToSession(ctx, remoteCmd); err != nil {
 		result.Error = err
-		result.Output = output
 		result.Duration = time.Since(start)
 		if re.Verbose {
 			warnf("Remote execution failed: %v", err)
@@ -141,7 +143,13 @@ func (re *RemoteExecutor) ExecuteStage(stage Stage) Result {
 	exitCode, err := re.pollExitCode(ctx, sentinelFile)
 	if err != nil {
 		result.Error = fmt.Errorf("failed to get exit code: %w", err)
-		result.Output = output
+		result.Duration = time.Since(start)
+		return result
+	}
+
+	output, err := re.captureSessionOutput(ctx)
+	if err != nil {
+		result.Error = fmt.Errorf("failed to capture output: %w", err)
 		result.Duration = time.Since(start)
 		return result
 	}
@@ -161,11 +169,11 @@ func (re *RemoteExecutor) ExecuteStage(stage Stage) Result {
 	return result
 }
 
-// runInSession executes a command within a tmux session
-func (re *RemoteExecutor) runInSession(ctx context.Context, cmd string) (string, error) {
+// sendToSession dispatches a command into a tmux session without waiting for completion.
+func (re *RemoteExecutor) sendToSession(ctx context.Context, cmd string) error {
 	initCmd := fmt.Sprintf(
 		"tmux new-session -d -s %s -c %s 'sleep 999999' 2>/dev/null; true",
-		re.Session,
+		escapeShellArg(re.Session),
 		escapeShellArg(re.WorkDir),
 	)
 
@@ -177,22 +185,24 @@ func (re *RemoteExecutor) runInSession(ctx context.Context, cmd string) (string,
 
 	sendCmd := fmt.Sprintf(
 		"tmux send-keys -t %s '%s' Enter",
-		re.Session,
+		escapeShellArg(re.Session),
 		escapeForTmux(cmd),
 	)
 
 	if err := re.sshExec(ctx, sendCmd); err != nil {
-		return "", fmt.Errorf("failed to send command to tmux: %w", err)
+		return fmt.Errorf("failed to send command to tmux: %w", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	return nil
+}
 
-	captureCmd := fmt.Sprintf("tmux capture-pane -t %s -p", re.Session)
+// captureSessionOutput reads the current tmux pane after a stage completes.
+func (re *RemoteExecutor) captureSessionOutput(ctx context.Context) (string, error) {
+	captureCmd := fmt.Sprintf("tmux capture-pane -t %s -p", escapeShellArg(re.Session))
 	output, err := re.sshExecWithOutput(ctx, captureCmd)
 	if err != nil {
 		return "", fmt.Errorf("failed to capture output: %w", err)
 	}
-
 	return output, nil
 }
 
@@ -259,7 +269,7 @@ func escapeForTmux(cmd string) string {
 func (re *RemoteExecutor) EnsureRemoteSession(ctx context.Context) error {
 	cmd := fmt.Sprintf(
 		"tmux new-session -d -s %s -c %s 'sleep 999999' 2>/dev/null || true",
-		re.Session,
+		escapeShellArg(re.Session),
 		escapeShellArg(re.WorkDir),
 	)
 	return re.sshExec(ctx, cmd)
@@ -267,7 +277,7 @@ func (re *RemoteExecutor) EnsureRemoteSession(ctx context.Context) error {
 
 // KillRemoteSession kills the remote tmux session
 func (re *RemoteExecutor) KillRemoteSession(ctx context.Context) error {
-	cmd := fmt.Sprintf("tmux kill-session -t %s 2>/dev/null || true", re.Session)
+	cmd := fmt.Sprintf("tmux kill-session -t %s 2>/dev/null || true", escapeShellArg(re.Session))
 	return re.sshExec(ctx, cmd)
 }
 

--- a/remote_test.go
+++ b/remote_test.go
@@ -64,9 +64,10 @@ func TestBuildRemoteStageCommand(t *testing.T) {
 }
 
 type mockSSH struct {
-	calls    []string
-	exitCode string
-	failOn   string
+	calls         []string
+	exitCode      string
+	captureOutput string
+	failOn        string
 }
 
 func (m *mockSSH) execWithOutput(_ context.Context, cmd string) (string, error) {
@@ -75,6 +76,9 @@ func (m *mockSSH) execWithOutput(_ context.Context, cmd string) (string, error) 
 		return "", context.DeadlineExceeded
 	}
 	if strings.Contains(cmd, "capture-pane") {
+		if m.captureOutput != "" {
+			return m.captureOutput, nil
+		}
 		return "stage output\n", nil
 	}
 	if strings.Contains(cmd, "cat /tmp/kc_exit_") {
@@ -149,6 +153,49 @@ func TestRemoteExecutorSSHFailure(t *testing.T) {
 	}
 	if result.Error == nil {
 		t.Fatal("expected SSH error")
+	}
+}
+
+func TestRemoteExecutorCaptureAfterCompletion(t *testing.T) {
+	mock := &mockSSH{exitCode: "0\n", captureOutput: "final output line\n"}
+	re := NewRemoteExecutor("aivcs@test", "onion", "/tmp/project", 30*time.Second, false)
+	re.ssh = mock
+
+	stage := Stage{
+		Name:    "fmt",
+		Cmd:     []string{"echo", "hello"},
+		Timeout: 5,
+		Enabled: true,
+	}
+
+	result := re.ExecuteStage(stage)
+	if result.Status != "pass" {
+		t.Fatalf("expected pass, got %s (%v)", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Output, "final output line") {
+		t.Errorf("expected post-completion capture, got %q", result.Output)
+	}
+
+	captureIdx := -1
+	catIdx := -1
+	for i, call := range mock.calls {
+		if strings.Contains(call, "capture-pane") {
+			captureIdx = i
+		}
+		if strings.Contains(call, "cat /tmp/kc_exit_") {
+			catIdx = i
+		}
+	}
+	if captureIdx == -1 || catIdx == -1 || captureIdx <= catIdx {
+		t.Fatalf("capture-pane should run after sentinel read; calls=%v", mock.calls)
+	}
+}
+
+func TestRemoteExecutorEmptyCommand(t *testing.T) {
+	re := NewRemoteExecutor("aivcs@test", "onion", "/tmp/project", 30*time.Second, false)
+	result := re.ExecuteStage(Stage{Name: "empty"})
+	if result.Status != "fail" || result.Error == nil {
+		t.Fatalf("expected fail for empty command, got %+v", result)
 	}
 }
 

--- a/stage_cache_test.go
+++ b/stage_cache_test.go
@@ -238,6 +238,39 @@ func TestStageHashIgnoresTargetDir(t *testing.T) {
 	}
 }
 
+func TestComputeSourceHashExactFilename(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/foo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := &Config{
+		Cache: CacheConfig{
+			SkipDirs:        []string{".git"},
+			IncludePatterns: []string{"go.mod", "*.go"},
+		},
+	}
+
+	hashWithMod, err := computeSourceHash(dir, config, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/bar\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hashAfterMod, err := computeSourceHash(dir, config, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hashWithMod == hashAfterMod {
+		t.Fatal("go.mod changes should affect source hash")
+	}
+}
+
 func TestMatchesPatterns(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Unify cache keys (`hash|command`) across CLI, MCP, and dry-run with legacy hash-only compatibility
- Fix remote SSH execution to capture tmux output after the exit sentinel appears (not after 100ms)
- Fix parallel runner: per-stage watch hashes, cache persistence, fail-fast ordering/deadlock, empty-command guard
- Fix `--all` to actually enable disabled stages; normalize bare `--remote` hostnames; reject `--parallel` + `--remote`
- Use `matchesPatterns` in `computeSourceHash` so exact filenames like `go.mod` affect cache keys

## Test plan
- [x] Build & Test (CI)
- [x] Nix Flake Check (CI)
- [ ] Human review: cache key migration impact on existing `.local-ci-cache` files
- [ ] Operator: optional remote smoke on tailnet hosts