### PR TITLE
Fix Node.js project detection precedence (#74)

### DIFF
--- a/project_type.go
+++ b/project_type.go
@@ -27,12 +27,10 @@ func DetectProjectType(root string) ProjectType {
 		return ProjectTypeRust
 	}
 
-	// Check for Node.js/TypeScript project files
+	// package.json is an explicit Node marker — check before Swift/Python
+	// so monorepos with requirements.txt or Package.swift still get npm/bun stages.
 	if fileExists(filepath.Join(root, "package.json")) {
-		// Optimization: if it's package.json but also has TS indicators
-		if DetectProjectKind(root) == ProjectKindTypeScript {
-			return ProjectTypeNode
-		}
+		return ProjectTypeNode
 	}
 
 	// Check for Swift project files
@@ -58,11 +56,6 @@ func DetectProjectType(root string) ProjectType {
 		fileExists(filepath.Join(root, "setup.py")) ||
 		fileExists(filepath.Join(root, "requirements.txt")) {
 		return ProjectTypePython
-	}
-
-	// Check for Node.js project files (fallback)
-	if fileExists(filepath.Join(root, "package.json")) {
-		return ProjectTypeNode
 	}
 
 	// Check for Go project files

--- a/project_type_test.go
+++ b/project_type_test.go
@@ -49,6 +49,32 @@ func TestDetectProjectTypeNode(t *testing.T) {
 	}
 }
 
+func TestDetectProjectTypeNodeBeatsPythonMarkers(t *testing.T) {
+	tmpdir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpdir, "package.json"), []byte(`{"name":"app"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpdir, "requirements.txt"), []byte("pytest\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectProjectType(tmpdir); got != ProjectTypeNode {
+		t.Fatalf("expected ProjectTypeNode when package.json + requirements.txt, got %s", got)
+	}
+}
+
+func TestDetectProjectTypeNodeBeatsSwiftMarker(t *testing.T) {
+	tmpdir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpdir, "package.json"), []byte(`{"name":"app"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpdir, "Package.swift"), []byte("// swift tools\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectProjectType(tmpdir); got != ProjectTypeNode {
+		t.Fatalf("expected ProjectTypeNode when package.json + Package.swift, got %s", got)
+	}
+}
+
 // TestDetectProjectTypeGo verifies Go project detection
 func TestDetectProjectTypeGo(t *testing.T) {
 	tmpdir := t.TempDir()


### PR DESCRIPTION
## Summary
- Closes #74
- `package.json` now unconditionally selects `ProjectTypeNode` before Swift/Python fallthrough
- Adds regression tests for `package.json` + `requirements.txt` and `package.json` + `Package.swift`

## Test plan
- [x] `go test ./... -run DetectProjectType`


Made with [Cursor](https://cursor.com)