### PR TITLE
Fix IsCacheInstalled false positives (#76)

### DIFF
--- a/nix-cache.go
+++ b/nix-cache.go
@@ -87,15 +87,30 @@ func parseSubstitutersFromConf(confPath string) []string {
 	return caches
 }
 
+// normalizeCacheURL trims trailing slashes for exact substituter comparison.
+func normalizeCacheURL(url string) string {
+	return strings.TrimRight(strings.TrimSpace(url), "/")
+}
+
+// getInstalledCachesHook is set in tests to avoid reading nix.conf.
+var getInstalledCachesHook func() ([]string, error)
+
 // IsCacheInstalled checks if a specific cache is already configured
 func IsCacheInstalled(cacheURL string) bool {
-	installed, err := GetInstalledCaches()
+	var installed []string
+	var err error
+	if getInstalledCachesHook != nil {
+		installed, err = getInstalledCachesHook()
+	} else {
+		installed, err = GetInstalledCaches()
+	}
 	if err != nil {
 		return false
 	}
 
+	want := normalizeCacheURL(cacheURL)
 	for _, cache := range installed {
-		if strings.Contains(cache, cacheURL) || strings.Contains(cacheURL, cache) {
+		if normalizeCacheURL(cache) == want {
 			return true
 		}
 	}

--- a/nix_cache_test.go
+++ b/nix_cache_test.go
@@ -92,6 +92,29 @@ func TestCacheTrustSettings(t *testing.T) {
 	}
 }
 
+func TestIsCacheInstalledExactMatch(t *testing.T) {
+	getInstalledCachesHook = func() ([]string, error) {
+		return []string{
+			"https://cache.nixos.org",
+			"https://nix-cache.stevedores.org/",
+		}, nil
+	}
+	t.Cleanup(func() { getInstalledCachesHook = nil })
+
+	if !IsCacheInstalled("https://cache.nixos.org/") {
+		t.Fatal("expected exact normalized match for cache.nixos.org")
+	}
+	if !IsCacheInstalled("https://nix-cache.stevedores.org") {
+		t.Fatal("expected stevedores cache match")
+	}
+	if IsCacheInstalled("https://cache.nixos.org/extra") {
+		t.Fatal("substring URL must not match configured cache.nixos.org")
+	}
+	if IsCacheInstalled("https://nix-cache.stevedores.org/evil") {
+		t.Fatal("substring URL must not match configured stevedores cache")
+	}
+}
+
 func TestIsCacheInstalled(t *testing.T) {
 	// This test depends on Nix installation
 	if !CheckNixInstallation() {


### PR DESCRIPTION
## Summary
- Closes #76
- Replace bidirectional `strings.Contains` with normalized exact URL match in `IsCacheInstalled`
- Regression tests for trailing-slash equivalence and substring false positives

## Test plan
- [x] `go test ./... -run IsCacheInstalled`


Made with [Cursor](https://cursor.com)