### PR TITLE
chore: point Nix substituter at nix-cache.lornu.ai

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   description = "local-ci - lightweight local CI runner";
 
   nixConfig = {
-    extra-substituters = [ "https://nix-cache.stevedores.org" ];
-    extra-trusted-public-keys = [ "stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag=" ];
+    extra-substituters = [ "https://nix-cache.lornu.ai" ];
+    extra-trusted-public-keys = [ "lornu-1:FSWe0oOoYoYzbDU3XsZOoUz6LYouAKynidEOop1Q8yc=" ];
   };
 
   inputs = {


### PR DESCRIPTION
Retargeted from aivcs-lornu-demo#17. This change moves the shared Nix cache configuration to point to `nix-cache.lornu.ai` instead of `nix-cache.stevedores.org`.