### PR TITLE
feat(yaml-lint): add go-based yaml-lint check stage

### DIFF
--- a/config.go
+++ b/config.go
@@ -79,6 +79,18 @@ func LoadConfig(root string, remote bool) (*Config, error) {
 	// Detect project type for smart defaults
 	projectType := DetectProjectType(root)
 	defaultStages := GetDefaultStagesForType(projectType)
+	if _, exists := defaultStages["yaml-lint"]; !exists {
+		defaultStages["yaml-lint"] = Stage{
+			Name:      "yaml-lint",
+			Cmd:       []string{"local-ci", "yamllint"},
+			FixCmd:    nil,
+			Check:     false,
+			Timeout:   120,
+			Enabled:   true,
+			DependsOn: []string{},
+			Watch:     []string{"*.yml", "*.yaml"},
+		}
+	}
 	cachePatterns := GetCachePatternForType(projectType)
 	skipDirs := GetSkipDirsForType(projectType)
 
@@ -293,6 +305,16 @@ func defaultStages() map[string]Stage {
 			DependsOn: []string{},
 			Watch:     []string{"*.toml"},
 		},
+		"yaml-lint": {
+			Name:      "yaml-lint",
+			Cmd:       []string{"local-ci", "yamllint"},
+			FixCmd:    nil,
+			Check:     false,
+			Timeout:   120,
+			Enabled:   true,
+			DependsOn: []string{},
+			Watch:     []string{"*.yml", "*.yaml"},
+		},
 	}
 }
 
@@ -322,7 +344,7 @@ func (c *Config) GetTimeout(stageName string) time.Duration {
 // GetEnabledStages returns the list of enabled stage names in deterministic order
 func (c *Config) GetEnabledStages() []string {
 	// Define default order for common stages to ensure deterministic output
-	order := []string{"fmt", "check", "clippy", "test", "lint", "vet", "types", "build", "audit", "deny", "machete", "taplo"}
+	order := []string{"fmt", "yaml-lint", "check", "clippy", "test", "lint", "vet", "types", "build", "audit", "deny", "machete", "taplo"}
 
 	var enabled []string
 	// First add stages in predefined order if they exist and are enabled
@@ -353,7 +375,7 @@ func (c *Config) GetEnabledStages() []string {
 // deterministic order — the same ordering as GetEnabledStages, but without the
 // enabled filter. Used by the --all flag.
 func (c *Config) GetAllStages() []string {
-	order := []string{"fmt", "check", "clippy", "test", "lint", "vet", "types", "build", "audit", "deny", "machete", "taplo"}
+	order := []string{"fmt", "yaml-lint", "check", "clippy", "test", "lint", "vet", "types", "build", "audit", "deny", "machete", "taplo"}
 
 	var all []string
 	seen := make(map[string]bool)

--- a/main.go
+++ b/main.go
@@ -249,6 +249,11 @@ func main() {
 				fatalf("MCP server error: %v", err)
 			}
 			return
+		} else if args[0] == "yamllint" {
+			if err := cmdYamllint(cwd); err != nil {
+				fatalf("yamllint error: %v", err)
+			}
+			return
 		}
 	}
 
@@ -663,7 +668,11 @@ func main() {
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
-			cmd := exec.CommandContext(ctx, stage.Cmd[0], stage.Cmd[1:]...)
+			exe := stage.Cmd[0]
+			if exe == "local-ci" {
+				exe = os.Args[0]
+			}
+			cmd := exec.CommandContext(ctx, exe, stage.Cmd[1:]...)
 			var out bytes.Buffer
 			cmd.Stdout = &out
 			cmd.Stderr = &out
@@ -1072,6 +1081,9 @@ func fatalf(format string, args ...interface{}) {
 
 // requireCommand checks if a command is available in PATH
 func requireCommand(name string) error {
+	if name == "local-ci" {
+		return nil
+	}
 	if _, err := exec.LookPath(name); err != nil {
 		return fmt.Errorf("%q not found in PATH", name)
 	}

--- a/parallel.go
+++ b/parallel.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"sync"
@@ -176,7 +177,11 @@ func (r *ParallelRunner) executeStage(stage Stage) Result {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, stage.Cmd[0], stage.Cmd[1:]...)
+	exe := stage.Cmd[0]
+	if exe == "local-ci" {
+		exe = os.Args[0]
+	}
+	cmd := exec.CommandContext(ctx, exe, stage.Cmd[1:]...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out

--- a/project_type.go
+++ b/project_type.go
@@ -59,7 +59,6 @@ func DetectProjectType(root string) ProjectType {
 		return ProjectTypePython
 	}
 
-
 	// Check for Go project files
 	if fileExists(filepath.Join(root, "go.mod")) {
 		return ProjectTypeGo
@@ -231,9 +230,6 @@ func getPythonStages() map[string]Stage {
 		},
 	}
 }
-
-
-
 
 // getGoStages returns Go specific stages
 func getGoStages() map[string]Stage {
@@ -518,8 +514,6 @@ optional = []
 exclude = []
 `
 }
-
-
 
 func getGoConfigTemplate() string {
 	return `# local-ci configuration for Go project

--- a/toolcheck.go
+++ b/toolcheck.go
@@ -111,6 +111,14 @@ var systemTools = []Tool{
 		ToolType:   "system",
 		Optional:   true,
 	},
+	{
+		Name:       "yamllint",
+		Command:    "yamllint",
+		CheckArgs:  []string{"--version"},
+		InstallCmd: "pip install yamllint",
+		ToolType:   "system",
+		Optional:   true,
+	},
 }
 
 // ToolCheck represents the result of checking for a tool

--- a/yamllint.go
+++ b/yamllint.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// findYAMLFiles recursively searches for all .yml and .yaml files, skipping excluded directories
+func findYAMLFiles(root string, skipDirs []string) ([]string, error) {
+	var files []string
+	skipSet := make(map[string]bool)
+	for _, dir := range skipDirs {
+		skipSet[dir] = true
+	}
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if skipSet[d.Name()] || d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		ext := filepath.Ext(path)
+		if ext == ".yml" || ext == ".yaml" {
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			files = append(files, rel)
+		}
+		return nil
+	})
+
+	return files, err
+}
+
+// cmdYamllint runs the yaml lint check using the python yamllint command and a temporary configuration file
+func cmdYamllint(root string) error {
+	// Check if yamllint is installed
+	if _, err := exec.LookPath("yamllint"); err != nil {
+		return fmt.Errorf("yamllint not found in PATH. Please install it using 'pip install yamllint' or 'brew install yamllint'")
+	}
+
+	// Load config to get skip_dirs
+	config, err := LoadConfig(root, false)
+	var skipDirs []string
+	if err == nil && config != nil {
+		skipDirs = config.Cache.SkipDirs
+	} else {
+		// Fallback defaults
+		skipDirs = []string{".git", "node_modules", "target", "build", "dist", ".venv", "venv"}
+	}
+
+	yamlFiles, err := findYAMLFiles(root, skipDirs)
+	if err != nil {
+		return fmt.Errorf("failed to scan for YAML files: %w", err)
+	}
+
+	if len(yamlFiles) == 0 {
+		fmt.Println("No YAML files found.")
+		return nil
+	}
+
+	// Create temporary yamllint config file
+	configContent := `extends: default
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length:
+    max: 160
+  truthy: disable
+`
+	tmpFile, err := os.CreateTemp("", "yamllint-*.yml")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary config file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(configContent); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to write to temporary config file: %w", err)
+	}
+	tmpFile.Close()
+
+	// Execute yamllint
+	args := append([]string{"-c", tmpFile.Name()}, yamlFiles...)
+	cmd := exec.Command("yamllint", args...)
+	cmd.Dir = root
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		// Exit code of the command is propagated
+		if exitError, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitError.ExitCode())
+		}
+		return fmt.Errorf("failed to run yamllint: %w", err)
+	}
+
+	return nil
+}

--- a/yamllint_test.go
+++ b/yamllint_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindYAMLFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "yamllint-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create test directories and files
+	dirsToCreate := []string{
+		"sub1",
+		"sub2",
+		"ignored_dir",
+		".git",
+	}
+	for _, d := range dirsToCreate {
+		if err := os.MkdirAll(filepath.Join(tmpDir, d), 0755); err != nil {
+			t.Fatalf("failed to create dir: %v", err)
+		}
+	}
+
+	filesToCreate := []string{
+		"file1.yml",
+		"file2.yaml",
+		filepath.Join("sub1", "file3.yml"),
+		filepath.Join("sub2", "file4.yaml"),
+		filepath.Join("ignored_dir", "file5.yml"),
+		filepath.Join(".git", "config.yml"),
+		"not_yaml.txt",
+	}
+	for _, f := range filesToCreate {
+		if err := os.WriteFile(filepath.Join(tmpDir, f), []byte(""), 0644); err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+	}
+
+	skipDirs := []string{"ignored_dir"}
+	found, err := findYAMLFiles(tmpDir, skipDirs)
+	if err != nil {
+		t.Fatalf("findYAMLFiles failed: %v", err)
+	}
+
+	expected := map[string]bool{
+		"file1.yml":       true,
+		"file2.yaml":      true,
+		"sub1/file3.yml":  true,
+		"sub2/file4.yaml": true,
+	}
+
+	if len(found) != len(expected) {
+		t.Errorf("expected %d files, got %d: %v", len(expected), len(found), found)
+	}
+
+	for _, f := range found {
+		if !expected[f] {
+			t.Errorf("unexpected file found: %s", f)
+		}
+	}
+}
+
+func TestCmdYamllintNoFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "yamllint-test-empty-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Should not return an error when no files are found
+	err = cmdYamllint(tmpDir)
+	if err != nil {
+		t.Errorf("expected no error when no yaml files found, got: %v", err)
+	}
+}


### PR DESCRIPTION
This PR adds a Go-based 'yaml-lint' stage to 'local-ci' that scans for .yml and .yaml files, generates a temporary configuration matching the rules in ci-checks PR #1, and runs yamllint.