### PR TITLE
[codex] fix yaml lint stage behavior

### DIFF
--- a/config.go
+++ b/config.go
@@ -530,7 +530,7 @@ func (c *Config) GetProfileStages(p *Profile) []string {
 	}
 
 	// Use the same ordering as GetEnabledStages
-	order := []string{"fmt", "check", "clippy", "test", "lint", "vet", "types", "build", "audit", "deny", "machete", "taplo"}
+	order := []string{"fmt", "yaml-lint", "check", "clippy", "test", "lint", "vet", "types", "build", "audit", "deny", "machete", "taplo"}
 	inProfile := make(map[string]bool)
 	for _, s := range p.Stages {
 		inProfile[s] = true

--- a/config_test.go
+++ b/config_test.go
@@ -232,18 +232,19 @@ func TestGetProfileReferencesUnknownStage(t *testing.T) {
 func TestGetProfileStagesOrder(t *testing.T) {
 	config := &Config{
 		Stages: map[string]Stage{
-			"test":   {Name: "test", Enabled: true},
-			"fmt":    {Name: "fmt", Enabled: true},
-			"clippy": {Name: "clippy", Enabled: true},
+			"test":      {Name: "test", Enabled: true},
+			"fmt":       {Name: "fmt", Enabled: true},
+			"clippy":    {Name: "clippy", Enabled: true},
+			"yaml-lint": {Name: "yaml-lint", Enabled: true},
 		},
 		Profiles: map[string]Profile{},
 	}
 
-	p := &Profile{Stages: []string{"test", "clippy", "fmt"}}
+	p := &Profile{Stages: []string{"test", "clippy", "yaml-lint", "fmt"}}
 	ordered := config.GetProfileStages(p)
 
-	// Should be sorted by priority: fmt(0) < clippy(1) < test(3)
-	expected := []string{"fmt", "clippy", "test"}
+	// Should be sorted by priority: fmt < yaml-lint < clippy < test
+	expected := []string{"fmt", "yaml-lint", "clippy", "test"}
 	for i, name := range expected {
 		if ordered[i] != name {
 			t.Errorf("position %d: expected %q, got %q (full: %v)", i, name, ordered[i], ordered)

--- a/yamllint.go
+++ b/yamllint.go
@@ -44,11 +44,6 @@ func findYAMLFiles(root string, skipDirs []string) ([]string, error) {
 
 // cmdYamllint runs the yaml lint check using the python yamllint command and a temporary configuration file
 func cmdYamllint(root string) error {
-	// Check if yamllint is installed
-	if _, err := exec.LookPath("yamllint"); err != nil {
-		return fmt.Errorf("yamllint not found in PATH. Please install it using 'pip install yamllint' or 'brew install yamllint'")
-	}
-
 	// Load config to get skip_dirs
 	config, err := LoadConfig(root, false)
 	var skipDirs []string
@@ -66,6 +61,11 @@ func cmdYamllint(root string) error {
 
 	if len(yamlFiles) == 0 {
 		fmt.Println("No YAML files found.")
+		return nil
+	}
+
+	if _, err := exec.LookPath("yamllint"); err != nil {
+		fmt.Println("yamllint not found in PATH; skipping YAML lint. Install it with 'pip install yamllint' or 'brew install yamllint'.")
 		return nil
 	}
 
@@ -99,9 +99,8 @@ rules:
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		// Exit code of the command is propagated
 		if exitError, ok := err.(*exec.ExitError); ok {
-			os.Exit(exitError.ExitCode())
+			return fmt.Errorf("yamllint failed with exit code %d", exitError.ExitCode())
 		}
 		return fmt.Errorf("failed to run yamllint: %w", err)
 	}

--- a/yamllint_test.go
+++ b/yamllint_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -76,5 +77,40 @@ func TestCmdYamllintNoFiles(t *testing.T) {
 	err = cmdYamllint(tmpDir)
 	if err != nil {
 		t.Errorf("expected no error when no yaml files found, got: %v", err)
+	}
+}
+
+func TestCmdYamllintSkipsWhenToolMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yml"), []byte("name: test\n"), 0644); err != nil {
+		t.Fatalf("failed to write yaml file: %v", err)
+	}
+
+	t.Setenv("PATH", tmpDir)
+
+	if err := cmdYamllint(tmpDir); err != nil {
+		t.Fatalf("expected missing optional yamllint to skip without error, got: %v", err)
+	}
+}
+
+func TestCmdYamllintReturnsFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yml"), []byte("name: test\n"), 0644); err != nil {
+		t.Fatalf("failed to write yaml file: %v", err)
+	}
+
+	binDir := t.TempDir()
+	fakeYamllint := filepath.Join(binDir, "yamllint")
+	if err := os.WriteFile(fakeYamllint, []byte("#!/bin/sh\nexit 7\n"), 0755); err != nil {
+		t.Fatalf("failed to write fake yamllint: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	err := cmdYamllint(tmpDir)
+	if err == nil {
+		t.Fatal("expected yamllint failure to return an error")
+	}
+	if !strings.Contains(err.Error(), "exit code 7") {
+		t.Fatalf("expected exit code in error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Keep `yamllint` optional by skipping the YAML lint stage with a clear warning when the binary is not installed.
- Discover YAML files before checking for the tool, so repos with no YAML do not require `yamllint`.
- Return lint failures as errors instead of calling `os.Exit` from helper code.
- Include `yaml-lint` in profile stage ordering and add regression coverage.

## Validation

- `env GOCACHE=/tmp/local-ci-go-cache go test ./...`
- `env GOCACHE=/tmp/local-ci-go-cache go run . --no-cache yaml-lint`

Follow-up to review of stevedores-org/local-ci#104.