### PR TITLE
[codex] include GitHub workflows in YAML lint

### DIFF
--- a/yamllint.go
+++ b/yamllint.go
@@ -42,6 +42,17 @@ func findYAMLFiles(root string, skipDirs []string) ([]string, error) {
 	return files, err
 }
 
+func yamlLintSkipDirs(skipDirs []string) []string {
+	filtered := make([]string, 0, len(skipDirs))
+	for _, dir := range skipDirs {
+		if dir == ".github" {
+			continue
+		}
+		filtered = append(filtered, dir)
+	}
+	return filtered
+}
+
 // cmdYamllint runs the yaml lint check using the python yamllint command and a temporary configuration file
 func cmdYamllint(root string) error {
 	// Load config to get skip_dirs
@@ -54,7 +65,7 @@ func cmdYamllint(root string) error {
 		skipDirs = []string{".git", "node_modules", "target", "build", "dist", ".venv", "venv"}
 	}
 
-	yamlFiles, err := findYAMLFiles(root, skipDirs)
+	yamlFiles, err := findYAMLFiles(root, yamlLintSkipDirs(skipDirs))
 	if err != nil {
 		return fmt.Errorf("failed to scan for YAML files: %w", err)
 	}

--- a/yamllint_test.go
+++ b/yamllint_test.go
@@ -66,6 +66,27 @@ func TestFindYAMLFiles(t *testing.T) {
 	}
 }
 
+func TestYAMLLintIncludesGithubWorkflows(t *testing.T) {
+	tmpDir := t.TempDir()
+	workflowDir := filepath.Join(tmpDir, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0755); err != nil {
+		t.Fatalf("failed to create workflow dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), []byte("name: ci\n"), 0644); err != nil {
+		t.Fatalf("failed to write workflow file: %v", err)
+	}
+
+	found, err := findYAMLFiles(tmpDir, yamlLintSkipDirs([]string{".git", ".github", "target"}))
+	if err != nil {
+		t.Fatalf("findYAMLFiles failed: %v", err)
+	}
+
+	expected := filepath.Join(".github", "workflows", "ci.yml")
+	if len(found) != 1 || found[0] != expected {
+		t.Fatalf("expected %q to be linted, got %v", expected, found)
+	}
+}
+
 func TestCmdYamllintNoFiles(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "yamllint-test-empty-*")
 	if err != nil {


### PR DESCRIPTION
## Summary

- Update the `yaml-lint` file discovery path to include `.github` workflow and action YAML files even when `.github` is excluded from the general cache skip list.
- Add a regression test proving `.github/workflows/*.yml` is linted.

## Validation

- `env GOCACHE=/tmp/local-ci-go-cache go test ./...`
- Built `/tmp/local-ci-pr105-fixed` from this branch.
- Ran `/tmp/local-ci-pr105-fixed --verbose --no-cache yaml-lint` against `lornu-ai/oci-dockworker-build` PR 5 and confirmed it catches `.github/workflows/build-oci-images.yml` violations.

## PR 5 Use Case Result

The updated local-ci check fails PR 5 as expected:

```text
.github/workflows/build-oci-images.yml
  108:161   error    line too long (266 > 160 characters)  (line-length)
  109:161   error    line too long (303 > 160 characters)  (line-length)
  390:1     error    too many blank lines (3 > 2)  (empty-lines)
```

This fixes the previous false pass where `yaml-lint` reported `No YAML files found.` because `.github` was skipped.